### PR TITLE
no weapontype in default script for WW Monk

### DIFF
--- a/Scripts.lua
+++ b/Scripts.lua
@@ -175,8 +175,6 @@ function OvaleScripts:GetDefaultScriptName(class, specialization)
 				talentChoice = "ce"
 			end
 			name = format("simulationcraft_monk_brewmaster_%s_%s_t17m", weaponType, talentChoice)
-		elseif specialization == "windwalker" then
-			name = format("simulationcraft_monk_windwalker_t18m")
 		end
 	elseif class == "PALADIN" then
 		if specialization == "holy" then

--- a/Scripts.lua
+++ b/Scripts.lua
@@ -176,7 +176,7 @@ function OvaleScripts:GetDefaultScriptName(class, specialization)
 			end
 			name = format("simulationcraft_monk_brewmaster_%s_%s_t17m", weaponType, talentChoice)
 		elseif specialization == "windwalker" then
-			name = format("simulationcraft_monk_windwalker_%s_t18m", weaponType)
+			name = format("simulationcraft_monk_windwalker_t18m")
 		end
 	elseif class == "PALADIN" then
 		if specialization == "holy" then


### PR DESCRIPTION
Simulationcraft no longer provides seperate 1H and 2H scripts for WW. Assumes 1H anyway.