### PR TITLE
use death_strike instead of plague_strike

### DIFF
--- a/SimulationCraft.lua
+++ b/SimulationCraft.lua
@@ -4018,14 +4018,14 @@ local function InsertSupportingFunctions(child, annotation)
 		local fmt = [[
 			AddFunction %sGetInMeleeRange
 			{
-				if CheckBoxOn(opt_melee_range) and not target.InRange(plague_strike) Texture(misc_arrowlup help=L(not_in_melee_range))
+				if CheckBoxOn(opt_melee_range) and not target.InRange(death_strike) Texture(misc_arrowlup help=L(not_in_melee_range))
 			}
 		]]
 		local code = format(fmt, camelSpecialization)
 		local node = OvaleAST:ParseCode("add_function", code, nodeList, annotation.astAnnotation)
 		tinsert(child, 1, node)
 		annotation.functionTag[node.name] = "shortcd"
-		AddSymbol(annotation, "plague_strike")
+		AddSymbol(annotation, "death_strike")
 		count = count + 1
 	end
 	if annotation.skull_bash == "DRUID" then

--- a/scripts/ovale_deathknight.lua
+++ b/scripts/ovale_deathknight.lua
@@ -29,7 +29,7 @@ AddFunction FrostDualWieldUsePotionStrength
 
 AddFunction FrostDualWieldGetInMeleeRange
 {
-	if CheckBoxOn(opt_melee_range) and not target.InRange(plague_strike) Texture(misc_arrowlup help=L(not_in_melee_range))
+	if CheckBoxOn(opt_melee_range) and not target.InRange(death_strike) Texture(misc_arrowlup help=L(not_in_melee_range))
 }
 
 ### actions.default
@@ -318,7 +318,7 @@ AddFunction FrostTwoHanderUsePotionStrength
 
 AddFunction FrostTwoHanderGetInMeleeRange
 {
-	if CheckBoxOn(opt_melee_range) and not target.InRange(plague_strike) Texture(misc_arrowlup help=L(not_in_melee_range))
+	if CheckBoxOn(opt_melee_range) and not target.InRange(death_strike) Texture(misc_arrowlup help=L(not_in_melee_range))
 }
 
 ### actions.default
@@ -607,7 +607,7 @@ AddFunction UnholyUsePotionStrength
 
 AddFunction UnholyGetInMeleeRange
 {
-	if CheckBoxOn(opt_melee_range) and not target.InRange(plague_strike) Texture(misc_arrowlup help=L(not_in_melee_range))
+	if CheckBoxOn(opt_melee_range) and not target.InRange(death_strike) Texture(misc_arrowlup help=L(not_in_melee_range))
 }
 
 ### actions.default


### PR DESCRIPTION
plague_strike is no longer a baseline spell for all death knights. Using death_strike instead to determine melee range.
Closes #44 