### PR TITLE
Separate cooldown and waiting on resources

### DIFF
--- a/Icon.lua
+++ b/Icon.lua
@@ -62,7 +62,7 @@ local function SetValue(self, value, actionTexture)
 end
 
 local function Update(self, element, startTime, actionTexture, actionInRange, actionCooldownStart, actionCooldownDuration,
-				actionUsable, actionShortcut, actionIsCurrent, actionEnable, actionType, actionId, actionTarget)
+				actionUsable, actionShortcut, actionIsCurrent, actionEnable, actionType, actionId, actionTarget, actionResourceExtend)
 	self.actionType = actionType
 	self.actionId = actionId
 	self.value = nil
@@ -126,13 +126,7 @@ local function Update(self, element, startTime, actionTexture, actionInRange, ac
 		end
 
 		-- Icon color overlay (red or not red).
-		local red = false
-		if startTime > actionCooldownStart + actionCooldownDuration + 0.01
-				and startTime > now
-				and startTime > state.nextCast then
-			red = true
-		end
-		if red then
+		if element.namedParams.nored ~= 1 and actionResourceExtend > 0 then
 			self.icone:SetVertexColor(0.75, 0.2, 0.2)
 		else
 			self.icone:SetVertexColor(1, 1, 1)

--- a/Power.lua
+++ b/Power.lua
@@ -708,13 +708,16 @@ end
 
 -- Return the number of seconds before enough of the given power type is available for the spell.
 -- If not powerType is given, the the pooled resource for that class is used.
-statePrototype.TimeToPower = function(state, spellId, atTime, targetGUID, powerType)
+statePrototype.TimeToPower = function(state, spellId, atTime, targetGUID, powerType, extraPower)
 	local seconds = 0
 	powerType = powerType or OvalePower.POOLED_RESOURCE[state.class]
 	if powerType then
 		local cost = state:PowerCost(spellId, powerType, atTime, targetGUID)
 		local power = state:GetPower(powerType, atTime)
 		local powerRate = state.powerRate[powerType]
+		if extraPower then
+			cost = cost + extraPower
+		end
 		if power < cost then
 			if powerRate > 0 then
 				seconds = (cost - power) / powerRate

--- a/SpellBook.lua
+++ b/SpellBook.lua
@@ -494,7 +494,7 @@ statePrototype.IsUsableSpell = function(state, spellId, atTime, targetGUID)
 end
 
 -- Get the number of seconds before the spell is ready to be cast, either due to cooldown or resources.
-statePrototype.GetTimeToSpell = function(state, spellId, atTime, targetGUID)
+statePrototype.GetTimeToSpell = function(state, spellId, atTime, targetGUID, extraPower)
 	if type(atTime) == "string" and not targetGUID then
 		atTime, targetGUID = nil, atTime
 	end
@@ -511,7 +511,7 @@ statePrototype.GetTimeToSpell = function(state, spellId, atTime, targetGUID)
 	end
 	-- Pooled resource.
 	do
-		local seconds = state:TimeToPower(spellId, atTime, targetGUID)
+		local seconds = state:TimeToPower(spellId, atTime, targetGUID, _, extraPower)
 		if timeToSpell < seconds then
 			timeToSpell = seconds
 		end


### PR DESCRIPTION
Simulationcraft will stop evaluating the action list at the point where
a pool_resource line resolves to true.  Since Ovale evaluates the entire
action list before determining an action, the equivilent in Ovale is to
ignore the resource requirement when determining the best action.

Separates out the normal cooldown (or GCD) information from the extra
time required to pool resources for a spell.

pool_resource=1 will cause BestAction to ignore any additional time
needed for resource requirements.  This mimics Simulationcraft's
pool_resource,for_next=1 functionality.

extra_amount=# will increase the cost of an ability by that amount.  It
can be used with pool_resource=1 to mimic the
pool_resource,for_next=1,extra_amount=# functionality or on an ability
that consumes extra resources such as Ferocious Bite.

Fixed the red icon color and changed it to simply reference the now
separate actionResourcExtend.  If the nored parameter does not equal 1
and actionResourceExtend is greater than 0, then change the icon color
to red to indicate we are waiting on a lack of resources.

The simcraft translator should be updated to utilize this new
functionality on any pool_resource,for_next=1 or
pool_resource,for_next=1,extra_amount=# where # is a defined number.
Calculated numbers will still have to use if/unless logic but the only
script I've seen those in is the Rogue Subtlety script.