### PR TITLE
the value of _ seems to be unpredictable

### DIFF
--- a/SpellBook.lua
+++ b/SpellBook.lua
@@ -511,7 +511,7 @@ statePrototype.GetTimeToSpell = function(state, spellId, atTime, targetGUID, ext
 	end
 	-- Pooled resource.
 	do
-		local seconds = state:TimeToPower(spellId, atTime, targetGUID, _, extraPower)
+		local seconds = state:TimeToPower(spellId, atTime, targetGUID, nil, extraPower)
 		if timeToSpell < seconds then
 			timeToSpell = seconds
 		end


### PR DESCRIPTION
Which I think it's weird, because _ isn't even used in variable scope.
The goal of the GetTimeToSpell is to use the class's default power anyway.
fixes #78