### PR TITLE
Fix conditions.lua BuffCount

### DIFF
--- a/conditions.lua
+++ b/conditions.lua
@@ -351,7 +351,7 @@ do
 		local count = 0
 		for id in pairs(spellList) do
 			local si = OvaleData.spellInfo[id]
-			local aura = state:GetAura(target, auraId, filter, mine)
+			local aura = state:GetAura(target, id, filter, mine)
 			if state:IsActiveAura(aura, atTime) then
 				count = count + 1
 			end


### PR DESCRIPTION
The current code gets the spell list from its virtual buff id correctly. 
But when iterating the list it used the virtual ID instead of the current list element resulting in either 0 or ListSize as returnValue instead of a count