### PR TITLE
Add missing DH spells

### DIFF
--- a/scripts/ovale_demonhunter_spells.lua
+++ b/scripts/ovale_demonhunter_spells.lua
@@ -84,7 +84,14 @@ Define(empower_wards 218256)
 	SpellAddBuff(empower_wards empower_wards_buff=1)
 Define(empower_wards_buff 218256)
 	SpellInfo(empower_wards_buff duration=6)
-
+Define(soul_fragments 203981)
+	SpellInfo(soul_fragments duration=20)		
+Define(soul_barrier 227225)
+	SpellInfo(soul_barrier cd=20)
+Define(spirit_bomb 218679)	
+Define(fel_devastation 212084)
+	SpellInfo(fel_devastation cd=60)
+Define(fracture 209795)	
 ]]
 
 	OvaleScripts:RegisterScript("DEMONHUNTER", nil, name, desc, code, "include")


### PR DESCRIPTION
It allows me to use the SimCraft rotation (excluding infernal strike).

I don't know how to track if=!sigil_placed

```
    if target.DebuffExpires(frailty_debuff) Spell(spirit_bomb)
    if target.DebuffPresent(fiery_brand_debuff) Spell(soul_carver)
    if Pain() <= 80 Spell(immolation_aura)
    if Pain() <= 70 Spell(felblade)
    if Pain() >= 30 Spell(soul_barrier)
    if Pain() >= 30 and BuffStacks(soul_fragments) == 5 Spell(soul_cleave)
    if BuffExpires(demon_spikes_buff) and not target.DebuffPresent(fiery_brand_debuff) and BuffExpires(metamorphosis_veng_buff) and IncomingDamage(5) > MaxHealth() * 0.7 Spell(metamorphosis_veng)
    if Pain() >= 30 and IncomingDamage(5) > MaxHealth() * 0.7 Spell(fel_devastation)
    if Pain() >= 30 and IncomingDamage(5) >= MaxHealth() * 0.7 Spell(soul_cleave)
    if target.DebuffRemaining(sigil_of_flame_debuff) <= 0.3 * BaseDuration(sigil_of_flame_debuff) Spell(sigil_of_flame)
    if Pain() >= 80 and BuffStacks(soul_fragments) < 4 and IncomingDamage(4) <= MaxHealth() * 0.2 Spell(fracture)
    if Pain() >= 80 Spell(soul_cleave)
    Spell(shear)
```