### PR TITLE
TimeToDie fix

### DIFF
--- a/dist/conditions.lua
+++ b/dist/conditions.lua
@@ -1072,7 +1072,7 @@ local function TimeToDie(positionalParams, namedParams, state, atTime)
         local timeToDie = OvaleHealth:UnitTimeToDie(target)
         local value, origin, rate = timeToDie, now, -1
         local start, ending = now, now + timeToDie
-        return TestValue(start, ending, value, origin, rate, comparator, limit)
+        return TestValue(start, INFINITY, value, origin, rate, comparator, limit)
     end
     OvaleCondition:RegisterCondition("deadin", false, TimeToDie)
     OvaleCondition:RegisterCondition("timetodie", false, TimeToDie)

--- a/src/conditions.ts
+++ b/src/conditions.ts
@@ -1852,7 +1852,7 @@ function GetHastedTime(seconds, haste, state: BaseState) {
         let timeToDie = OvaleHealth.UnitTimeToDie(target);
         let [value, origin, rate] = [timeToDie, now, -1];
         let [start, ending] = [now, now + timeToDie];
-        return TestValue(start, ending, value, origin, rate, comparator, limit);
+        return TestValue(start, INFINITY, value, origin, rate, comparator, limit);
     }
     OvaleCondition.RegisterCondition("deadin", false, TimeToDie);
     OvaleCondition.RegisterCondition("timetodie", false, TimeToDie);


### PR DESCRIPTION
TimeToDie should always return a value.  It would return `undefined` (`nil`) if the mob was estimated to die before the end of you could cast your next spell.