### PR TITLE
Hide range indicator when not needed

### DIFF
--- a/dist/Icon.lua
+++ b/dist/Icon.lua
@@ -156,14 +156,14 @@ __exports.OvaleIcon = __class(nil, {
             else
                 self.shortcut:Hide()
             end
-            if actionInRange then
+            if actionInRange == nil then
+                self.rangeIndicator:Hide()
+            elseif actionInRange then
                 self.rangeIndicator:SetVertexColor(0.6, 0.6, 0.6)
                 self.rangeIndicator:Show()
-            elseif  not actionInRange then
+            else
                 self.rangeIndicator:SetVertexColor(1, 0.1, 0.1)
                 self.rangeIndicator:Show()
-            else
-                self.rangeIndicator:Hide()
             end
             if element.namedParams.text then
                 self.focusText:SetText(tostring(element.namedParams.text))

--- a/dist/Spells.lua
+++ b/dist/Spells.lua
@@ -77,7 +77,7 @@ local OvaleSpellsClass = __class(OvaleSpellsBase, {
         if (returnValue == 1 and spellId == WARRIOR_INCERCEPT_SPELLID) then
             return (UnitIsFriend("player", unitId) == 1 or __exports.OvaleSpells:IsSpellInRange(WARRIOR_HEROICTHROW_SPELLID, unitId))
         end
-        return returnValue == 1
+        return (returnValue == 1 and true) or (returnValue == 0 and false) or (returnValue == nil and nil)
     end,
     CleanState = function(self)
     end,

--- a/src/Icon.ts
+++ b/src/Icon.ts
@@ -179,15 +179,15 @@ export class OvaleIcon {
             } else {
                 this.shortcut.Hide();
             }
-            if (actionInRange) {
+            if (actionInRange === undefined) {
+                this.rangeIndicator.Hide();   
+            } else if (actionInRange) {
                 this.rangeIndicator.SetVertexColor(0.6, 0.6, 0.6);
                 this.rangeIndicator.Show();
-            } else if (!actionInRange) {
+            } else {
                 this.rangeIndicator.SetVertexColor(1.0, 0.1, 0.1);
                 this.rangeIndicator.Show();
-            } else {
-                this.rangeIndicator.Hide();
-            }
+            } 
             if (element.namedParams.text) {
                 this.focusText.SetText(tostring(element.namedParams.text));
                 this.focusText.Show();

--- a/src/Spells.ts
+++ b/src/Spells.ts
@@ -54,7 +54,7 @@ class OvaleSpellsClass extends OvaleSpellsBase {
         }
     }
 
-    IsSpellInRange(spellId: number, unitId: string): boolean {
+    IsSpellInRange(spellId: number, unitId: string): boolean | undefined {
         let [index, bookType] = OvaleSpellBook.GetSpellBookIndex(spellId);
         let returnValue: number = undefined;
         if (index && bookType) {
@@ -66,7 +66,7 @@ class OvaleSpellsClass extends OvaleSpellsBase {
         if ((returnValue == 1 && spellId == WARRIOR_INCERCEPT_SPELLID)) {
             return (UnitIsFriend("player", unitId) == 1 || OvaleSpells.IsSpellInRange(WARRIOR_HEROICTHROW_SPELLID, unitId));
         }
-        return returnValue === 1;
+        return (returnValue == 1 && true) || (returnValue == 0 && false) || (returnValue === undefined && undefined);
     }
     
     RequireSpellCountHandler = (spellId: number, atTime: number, requirement: string, tokens: Tokens, index: number, targetGUID: string):[boolean, string, number] => {


### PR DESCRIPTION
The range of spells has 3 different values
1: spell in range
0: spell not in range
nil: range not applicable (no target, spell has no range fi buffs or aoe spells)