### PR TITLE
Enhance ItemRequire and SpellRequire to allow "OR" conditionals.

### DIFF
--- a/dist/Compile.lua
+++ b/dist/Compile.lua
@@ -45,6 +45,7 @@ local kpairs = pairs
 local find = string.find
 local match = string.match
 local sub = string.sub
+local insert = table.insert
 local GetSpellInfo = GetSpellInfo
 local __tools = LibStub:GetLibrary("ovale/tools")
 local isLuaArray = __tools.isLuaArray
@@ -272,10 +273,15 @@ local function EvaluateItemRequire(node)
         local count = 0
         local ii = OvaleData:ItemInfo(itemId)
         local tbl = ii.require[property] or {}
+        local arr = nil
         for k, v in kpairs(namedParams) do
             if  not checkToken(PARAMETER_KEYWORD, k) then
-                tbl[k] = v
-                count = count + 1
+                arr = tbl[k] or {}
+                if isLuaArray(arr) then
+                    insert(arr, v)
+                    tbl[k] = arr
+                    count = count + 1
+                end
             end
         end
         if count > 0 then
@@ -442,10 +448,15 @@ local function EvaluateSpellRequire(node)
         local count = 0
         local si = OvaleData:SpellInfo(spellId)
         local tbl = si.require[property] or {}
+        local arr = nil
         for k, v in kpairs(namedParams) do
             if  not checkToken(PARAMETER_KEYWORD, k) then
-                tbl[k] = v
-                count = count + 1
+                arr = tbl[k] or {}
+                if isLuaArray(arr) then
+                    insert(arr, v)
+                    tbl[k] = arr
+                    count = count + 1
+                end
             end
         end
         if count > 0 then

--- a/dist/Data.lua
+++ b/dist/Data.lua
@@ -11,6 +11,7 @@ local __Requirement = LibStub:GetLibrary("ovale/Requirement")
 local nowRequirements = __Requirement.nowRequirements
 local CheckRequirements = __Requirement.CheckRequirements
 local type = type
+local ipairs = ipairs
 local pairs = pairs
 local tonumber = tonumber
 local wipe = wipe
@@ -411,11 +412,15 @@ local OvaleDataClass = __class(OvaleDataBase, {
         local value = ii and ii[property]
         local requirements = ii and ii.require[property]
         if requirements then
-            for v, requirement in pairs(requirements) do
-                local verified = CheckRequirements(itemId, atTime, requirement, 1, targetGUID)
-                if verified then
-                    value = tonumber(v) or v
-                    break
+            for v, rArray in pairs(requirements) do
+                if isLuaArray(rArray) then
+                    for _, requirement in ipairs(rArray) do
+                        local verified = CheckRequirements(itemId, atTime, requirement, 1, targetGUID)
+                        if verified then
+                            value = tonumber(v) or v
+                            break
+                        end
+                    end
                 end
             end
         end
@@ -427,11 +432,15 @@ local OvaleDataClass = __class(OvaleDataBase, {
         local value = si and si[property]
         local requirements = si and si.require[property]
         if requirements then
-            for v, requirement in pairs(requirements) do
-                local verified = CheckRequirements(spellId, atTime, requirement, 1, targetGUID)
-                if verified then
-                    value = tonumber(v) or v
-                    break
+            for v, rArray in pairs(requirements) do
+                if isLuaArray(rArray) then
+                    for _, requirement in ipairs(rArray) do
+                        local verified = CheckRequirements(spellId, atTime, requirement, 1, targetGUID)
+                        if verified then
+                            value = tonumber(v) or v
+                            break
+                        end
+                    end
                 end
             end
         end
@@ -450,13 +459,17 @@ local OvaleDataClass = __class(OvaleDataBase, {
         if atTime then
             local ratioRequirements = si and si.require[ratioParam]
             if ratioRequirements then
-                for v, requirement in pairs(ratioRequirements) do
-                    local verified = CheckRequirements(spellId, atTime, requirement, 1, targetGUID)
-                    if verified then
-                        if ratio ~= 0 then
-                            ratio = ratio * ((tonumber(v) / 100) or 1)
-                        else
-                            break
+                for v, rArray in pairs(ratioRequirements) do
+                    if isLuaArray(rArray) then
+                        for _, requirement in ipairs(rArray) do
+                            local verified = CheckRequirements(spellId, atTime, requirement, 1, targetGUID)
+                            if verified then
+                                if ratio ~= 0 then
+                                    ratio = ratio * ((tonumber(v) / 100) or 1)
+                                else
+                                    break
+                                end
+                            end
                         end
                     end
                 end
@@ -472,10 +485,14 @@ local OvaleDataClass = __class(OvaleDataBase, {
             if atTime then
                 local addRequirements = si and si.require[addParam]
                 if addRequirements then
-                    for v, requirement in pairs(addRequirements) do
-                        local verified = CheckRequirements(spellId, atTime, requirement, 1, targetGUID)
-                        if verified then
-                            value = value + (tonumber(v) or 0)
+                    for v, rArray in pairs(addRequirements) do
+                        if isLuaArray(rArray) then
+                            for _, requirement in ipairs(rArray) do
+                                local verified = CheckRequirements(spellId, atTime, requirement, 1, targetGUID)
+                                if verified then
+                                    value = value + (tonumber(v) or 0)
+                                end
+                            end
                         end
                     end
                 end

--- a/dist/Power.lua
+++ b/dist/Power.lua
@@ -25,6 +25,7 @@ local aceEvent = LibStub:GetLibrary("AceEvent-3.0", true)
 local ceil = math.ceil
 local INFINITY = math.huge
 local floor = math.floor
+local ipairs = ipairs
 local pairs = pairs
 local tostring = tostring
 local tonumber = tonumber
@@ -105,12 +106,16 @@ local PowerModule = __class(nil, {
             if ratio and ratio ~= 0 then
                 local addRequirements = si and si.require["add_" .. powerType .. "_from_aura"]
                 if addRequirements then
-                    for v, requirement in pairs(addRequirements) do
-                        local verified = CheckRequirements(spellId, atTime, requirement, 1, targetGUID)
-                        if verified then
-                            local aura = OvaleAura:GetAura("player", requirement[2], atTime, nil, true)
-                            if OvaleAura:IsActiveAura(aura, atTime) then
-                                cost = cost + (tonumber(v) or 0) * aura.stacks
+                    for v, rArray in pairs(addRequirements) do
+                        if isLuaArray(rArray) then
+                            for _, requirement in ipairs(rArray) do
+                                local verified = CheckRequirements(spellId, atTime, requirement, 1, targetGUID)
+                                if verified then
+                                    local aura = OvaleAura:GetAura("player", requirement[2], atTime, nil, true)
+                                    if OvaleAura:IsActiveAura(aura, atTime) then
+                                        cost = cost + (tonumber(v) or 0) * aura.stacks
+                                    end
+                                end
                             end
                         end
                     end
@@ -132,15 +137,19 @@ local PowerModule = __class(nil, {
                 else
                     local refundRequirements = si and si.require["refund_" .. powerType]
                     if refundRequirements then
-                        for v, requirement in pairs(refundRequirements) do
-                            local verified = CheckRequirements(spellId, atTime, requirement, 1, targetGUID)
-                            if verified then
-                                if v == "cost" then
-                                    spellRefund = spellCost
-                                elseif isNumber(v) then
+                        for v, rArray in pairs(refundRequirements) do
+                            if isLuaArray(rArray) then
+                                for _, requirement in ipairs(rArray) do
+                                    local verified = CheckRequirements(spellId, atTime, requirement, 1, targetGUID)
+                                    if verified then
+                                        if v == "cost" then
+                                            spellRefund = spellCost
+                                        elseif isNumber(v) then
+                                        end
+                                        refund = refund + (tonumber(v) or 0)
+                                        break
+                                    end
                                 end
-                                refund = refund + (tonumber(v) or 0)
-                                break
                             end
                         end
                     end

--- a/src/Compile.ts
+++ b/src/Compile.ts
@@ -16,6 +16,7 @@ import { checkBoxes, lists, ResetControls } from "./Controls";
 import aceEvent from "@wowts/ace_event-3.0";
 import { ipairs, pairs, tonumber, tostring, type, wipe, LuaArray, lualength, truthy, LuaObj, kpairs } from "@wowts/lua";
 import { find, match, sub } from "@wowts/string";
+import { insert } from "@wowts/table";
 import { GetSpellInfo } from "@wowts/wow-mock";
 import { isLuaArray, checkToken } from "./tools";
 
@@ -245,11 +246,16 @@ function EvaluateItemRequire(node: AstNode) {
         const property = node.property;
         let count = 0;
         let ii = OvaleData.ItemInfo(itemId);
-        let tbl = ii.require[property] || {}
+        let tbl = ii.require[property] || {};
+        let arr = undefined;
         for (const [k, v] of kpairs(namedParams)) {
             if (!checkToken(PARAMETER_KEYWORD, k)) {
-                tbl[k] = <any>v;
-                count = count + 1;
+                arr = tbl[k] || {};
+                if (isLuaArray(arr)) {
+                    insert(arr, v);
+                    tbl[k] = arr;
+                    count = count + 1;
+                }
             }
         }
         if (count > 0) {
@@ -415,10 +421,15 @@ function EvaluateSpellRequire(node: AstNode) {
         let count = 0;
         let si = OvaleData.SpellInfo(spellId);
         let tbl = si.require[property] || {};
+        let arr = undefined;
         for (const [k, v] of kpairs(namedParams)) {
             if (!checkToken(PARAMETER_KEYWORD, k)) {
-                tbl[k] = <any>v;
-                count = count + 1;
+                arr = tbl[k] || {};
+                if (isLuaArray(arr)) {
+                    insert(arr, v);
+                    tbl[k] = arr;
+                    count = count + 1;
+                }
             }
         }
         if (count > 0) {

--- a/src/Data.ts
+++ b/src/Data.ts
@@ -2,7 +2,7 @@ import { Ovale } from "./Ovale";
 import { OvaleGUID } from "./GUID";
 import { OvaleDebug } from "./Debug";
 import { nowRequirements, CheckRequirements } from "./Requirement";
-import { type, pairs, tonumber, wipe, truthy, LuaArray, LuaObj } from "@wowts/lua";
+import { type, ipairs, pairs, tonumber, wipe, truthy, LuaArray, LuaObj } from "@wowts/lua";
 import { find } from "@wowts/string";
 import { baseState } from "./BaseState";
 import { isLuaArray, isString } from "./tools";
@@ -507,11 +507,15 @@ class OvaleDataClass extends OvaleDataBase {
         let value = ii && ii[property];
         let requirements = ii && ii.require[property];
         if (requirements) {
-            for (const [v, requirement] of pairs(requirements)) {
-                let verified = CheckRequirements(itemId, atTime, requirement, 1, targetGUID);
-                if (verified) {
-                    value = tonumber(v) || v;
-                    break;
+            for (const [v, rArray] of pairs(requirements)) {
+                if (isLuaArray(rArray)) {
+                    for (const [, requirement] of ipairs<any>(rArray)) {
+                        let verified = CheckRequirements(itemId, atTime, requirement, 1, targetGUID);
+                        if (verified) {
+                            value = tonumber(v) || v;
+                            break;
+                        }
+                    }
                 }
             }
         }
@@ -533,11 +537,15 @@ class OvaleDataClass extends OvaleDataBase {
         let value = si && si[property];
         let requirements = si && si.require[property];
         if (requirements) {
-            for (const [v, requirement] of pairs(requirements)) {
-                let verified = CheckRequirements(spellId, atTime, requirement, 1, targetGUID);
-                if (verified) {
-                    value = tonumber(v) || v;
-                    break;
+            for (const [v, rArray] of pairs(requirements)) {
+                if (isLuaArray(rArray)) {
+                    for (const [, requirement] of ipairs<any>(rArray)) {
+                        let verified = CheckRequirements(spellId, atTime, requirement, 1, targetGUID);
+                        if (verified) {
+                            value = tonumber(v) || v;
+                            break;
+                        }
+                    }
                 }
             }
         }
@@ -566,13 +574,17 @@ class OvaleDataClass extends OvaleDataBase {
         if (atTime) {  
             let ratioRequirements = si && si.require[ratioParam];
             if (ratioRequirements) {
-                for (const [v, requirement] of pairs(ratioRequirements)) {
-                    let verified = CheckRequirements(spellId, atTime, requirement, 1, targetGUID);
-                    if (verified) {
-                        if (ratio != 0) {
-                            ratio = ratio * ((tonumber(v) / 100) || 1);
-                        } else {
-                            break;
+                for (const [v, rArray] of pairs(ratioRequirements)) {
+                    if (isLuaArray(rArray)) {
+                        for (const [, requirement] of ipairs<any>(rArray)) {
+                            let verified = CheckRequirements(spellId, atTime, requirement, 1, targetGUID);
+                            if (verified) {
+                                if (ratio != 0) {
+                                    ratio = ratio * ((tonumber(v) / 100) || 1);
+                                } else {
+                                    break;
+                                }
+                            }
                         }
                     }
                 }
@@ -588,10 +600,14 @@ class OvaleDataClass extends OvaleDataBase {
             if (atTime) {
                 let addRequirements = si && si.require[addParam];
                 if (addRequirements) {
-                    for (const [v, requirement] of pairs(addRequirements)) {
-                        let verified = CheckRequirements(spellId, atTime, requirement, 1, targetGUID);
-                        if (verified) {
-                            value = value + (tonumber(v) || 0);
+                    for (const [v, rArray] of pairs(addRequirements)) {
+                        if (isLuaArray(rArray)) {
+                            for (const [, requirement] of ipairs<any>(rArray)) {
+                                let verified = CheckRequirements(spellId, atTime, requirement, 1, targetGUID);
+                                if (verified) {
+                                    value = value + (tonumber(v) || 0);
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
ItemRequire() and SpellRequire() had a limitation where a property
was set to a particular value by associating only a single
requirement handler for that value.  For example:

   SpellRequire(stealth unusable 1=stealthed,1)
   SpellRequire(stealth unusable 1=combat,1)

Only the second handler "combat=1" is used because only one handler
could be associated with "unusable=1" (the second SpellRequire
effectively overwrote the first).

This commit allows for handlers for multiple requirements to be
collected into an array associated with that property's value.
Checking requirements now means checking if any of the handlers in
the array are true, effectively turning multiple ItemRequire() or
SpellRequire() commands into "OR" conditionals.

Fixes issue #530 where rogues are recommended to Stealth even while
stealthed.