### PR TITLE
In the function SpellCooldown the comparator/limit should be optional fixes #669

### DIFF
--- a/src/conditions.ts
+++ b/src/conditions.ts
@@ -3644,7 +3644,7 @@ l    */
                 }
             }
         }
-        if (!comparator || limit === undefined) return [];
+
         if (earliest == INFINITY) {
             return Compare(0, comparator, limit);
         } else if (earliest > 0) {


### PR DESCRIPTION
The function SpellCooldown has optional parameters in the comparator and limit variables. these are handed down to the TestValues function in which they are checked and handled appropriatly.

The current check forces the function to be called with a comparator which as far as i could see never happens as the comparison is done by a binary operator which uses the output of the spellcooldown function.