### PR TITLE
Add new conditions MagicDamageTaken() and PhysicalDamageTaken().

### DIFF
--- a/dist/conditions.lua
+++ b/dist/conditions.lua
@@ -689,13 +689,25 @@ __exports.OvaleConditions = __class(nil, {
             local value = 0
             if interval > 0 then
                 local total, totalMagic = self.OvaleDamageTaken:GetRecentDamage(interval)
-                if namedParams.magic == 1 then
-                    value = totalMagic
-                elseif namedParams.physical == 1 then
-                    value = total - totalMagic
-                else
-                    value = total
-                end
+                value = total
+            end
+            return Compare(value, comparator, limit)
+        end
+        self.MagicDamageTaken = function(positionalParams, namedParams, atTime)
+            local interval, comparator, limit = positionalParams[1], positionalParams[2], positionalParams[3]
+            local value = 0
+            if interval > 0 then
+                local total, totalMagic = self.OvaleDamageTaken:GetRecentDamage(interval)
+                value = totalMagic
+            end
+            return Compare(value, comparator, limit)
+        end
+        self.PhysicalDamageTaken = function(positionalParams, namedParams, atTime)
+            local interval, comparator, limit = positionalParams[1], positionalParams[2], positionalParams[3]
+            local value = 0
+            if interval > 0 then
+                local total, totalMagic = self.OvaleDamageTaken:GetRecentDamage(interval)
+                value = total - totalMagic
             end
             return Compare(value, comparator, limit)
         end
@@ -1934,6 +1946,10 @@ __exports.OvaleConditions = __class(nil, {
         ovaleCondition:RegisterCondition("damage", false, self.Damage)
         ovaleCondition:RegisterCondition("damagetaken", false, self.DamageTaken)
         ovaleCondition:RegisterCondition("incomingdamage", false, self.DamageTaken)
+        ovaleCondition:RegisterCondition("magicdamagetaken", false, self.MagicDamageTaken)
+        ovaleCondition:RegisterCondition("incomingmagicdamage", false, self.MagicDamageTaken)
+        ovaleCondition:RegisterCondition("physicaldamagetaken", false, self.PhysicalDamageTaken)
+        ovaleCondition:RegisterCondition("incomingphysicaldamage", false, self.PhysicalDamageTaken)
         ovaleCondition:RegisterCondition("diseasesremaining", false, self.DiseasesRemaining)
         ovaleCondition:RegisterCondition("diseasesticking", false, self.DiseasesTicking)
         ovaleCondition:RegisterCondition("diseasesanyticking", false, self.DiseasesAnyTicking)

--- a/dist/conditions.lua
+++ b/dist/conditions.lua
@@ -688,7 +688,7 @@ __exports.OvaleConditions = __class(nil, {
             local interval, comparator, limit = positionalParams[1], positionalParams[2], positionalParams[3]
             local value = 0
             if interval > 0 then
-                local total, totalMagic = self.OvaleDamageTaken:GetRecentDamage(interval)
+                local total, _ = self.OvaleDamageTaken:GetRecentDamage(interval)
                 value = total
             end
             return Compare(value, comparator, limit)
@@ -697,7 +697,7 @@ __exports.OvaleConditions = __class(nil, {
             local interval, comparator, limit = positionalParams[1], positionalParams[2], positionalParams[3]
             local value = 0
             if interval > 0 then
-                local total, totalMagic = self.OvaleDamageTaken:GetRecentDamage(interval)
+                local _, totalMagic = self.OvaleDamageTaken:GetRecentDamage(interval)
                 value = totalMagic
             end
             return Compare(value, comparator, limit)

--- a/src/conditions.ts
+++ b/src/conditions.ts
@@ -1640,7 +1640,7 @@ export class OvaleConditions {
         ];
         let value = 0;
         if (interval > 0) {
-            let [_, totalMagic] = this.OvaleDamageTaken.GetRecentDamage(
+            let [, totalMagic] = this.OvaleDamageTaken.GetRecentDamage(
                 interval
             );
             value = totalMagic;

--- a/src/conditions.ts
+++ b/src/conditions.ts
@@ -1584,24 +1584,17 @@ export class OvaleConditions {
         return Compare(value, comparator, limit);
     };
 
-    /**  Get the damage taken by the player in the previous time interval.
+    /**  Get the total damage taken by the player in the previous time interval.
 	 @name DamageTaken
 	 @paramsig number or boolean
 	 @param interval The number of seconds before now.
 	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
 	 @param number Optional. The number to compare against.
-	 @param magic Optional. By default, all damage is counted. Set "magic=1" to count only magic damage.
-	     Defaults to magic=0.
-	     Valid values: 0, 1
-	 @param physical Optional. By default, all damage is counted. Set "physical=1" to count only physical damage.
-	     Defaults to physical=0.
-	     Valid values: 0, 1
 	 @return The amount of damage taken in the previous interval.
 	 @return A boolean value for the result of the comparison.
 	 @see IncomingDamage
 	 @usage
 	 if DamageTaken(5) > 50000 Spell(death_strike)
-	 if DamageTaken(5 magic=1) > 0 Spell(antimagic_shell)
      */
     private DamageTaken = (
         positionalParams: LuaArray<any>,
@@ -1618,13 +1611,71 @@ export class OvaleConditions {
             let [total, totalMagic] = this.OvaleDamageTaken.GetRecentDamage(
                 interval
             );
-            if (namedParams.magic == 1) {
-                value = totalMagic;
-            } else if (namedParams.physical == 1) {
-                value = total - totalMagic;
-            } else {
-                value = total;
-            }
+            value = total;
+        }
+        return Compare(value, comparator, limit);
+    };
+
+    /**  Get the magic damage taken by the player in the previous time interval.
+	 @name MagicDamageTaken
+	 @paramsig number or boolean
+	 @param interval The number of seconds before now.
+	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
+	 @param number Optional. The number to compare against.
+	 @return The amount of magic damage taken in the previous interval.
+	 @return A boolean value for the result of the comparison.
+	 @see IncomingMagicDamage
+	 @usage
+	 if MagicDamageTaken(1.5) > 0 Spell(antimagic_shell)
+     */
+    private MagicDamageTaken = (
+        positionalParams: LuaArray<any>,
+        namedParams: LuaObj<any>,
+        atTime: number
+    ) => {
+        let [interval, comparator, limit] = [
+            positionalParams[1],
+            positionalParams[2],
+            positionalParams[3],
+        ];
+        let value = 0;
+        if (interval > 0) {
+            let [total, totalMagic] = this.OvaleDamageTaken.GetRecentDamage(
+                interval
+            );
+            value = totalMagic;
+        }
+        return Compare(value, comparator, limit);
+    };
+
+    /**  Get the physical damage taken by the player in the previous time interval.
+	 @name PhysicalDamageTaken
+	 @paramsig number or boolean
+	 @param interval The number of seconds before now.
+	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
+	 @param number Optional. The number to compare against.
+	 @return The amount of physical damage taken in the previous interval.
+	 @return A boolean value for the result of the comparison.
+	 @see IncomingPhysicalDamage
+	 @usage
+	 if PhysicalDamageTaken(1.5) > 0 Spell(shield_block)
+     */
+    private PhysicalDamageTaken = (
+        positionalParams: LuaArray<any>,
+        namedParams: LuaObj<any>,
+        atTime: number
+    ) => {
+        let [interval, comparator, limit] = [
+            positionalParams[1],
+            positionalParams[2],
+            positionalParams[3],
+        ];
+        let value = 0;
+        if (interval > 0) {
+            let [total, totalMagic] = this.OvaleDamageTaken.GetRecentDamage(
+                interval
+            );
+            value = total - totalMagic;
         }
         return Compare(value, comparator, limit);
     };
@@ -6773,6 +6824,26 @@ l    */
             "incomingdamage",
             false,
             this.DamageTaken
+        );
+        ovaleCondition.RegisterCondition(
+            "magicdamagetaken",
+            false,
+            this.MagicDamageTaken
+        );
+        ovaleCondition.RegisterCondition(
+            "incomingmagicdamage",
+            false,
+            this.MagicDamageTaken
+        );
+        ovaleCondition.RegisterCondition(
+            "physicaldamagetaken",
+            false,
+            this.PhysicalDamageTaken
+        );
+        ovaleCondition.RegisterCondition(
+            "incomingphysicaldamage",
+            false,
+            this.PhysicalDamageTaken
         );
         ovaleCondition.RegisterCondition(
             "diseasesremaining",

--- a/src/conditions.ts
+++ b/src/conditions.ts
@@ -1608,7 +1608,7 @@ export class OvaleConditions {
         ];
         let value = 0;
         if (interval > 0) {
-            let [total, totalMagic] = this.OvaleDamageTaken.GetRecentDamage(
+            let [total,] = this.OvaleDamageTaken.GetRecentDamage(
                 interval
             );
             value = total;
@@ -1640,7 +1640,7 @@ export class OvaleConditions {
         ];
         let value = 0;
         if (interval > 0) {
-            let [total, totalMagic] = this.OvaleDamageTaken.GetRecentDamage(
+            let [_, totalMagic] = this.OvaleDamageTaken.GetRecentDamage(
                 interval
             );
             value = totalMagic;


### PR DESCRIPTION
The new conditions have the following correspondences:

    DamageTaken(5 magic=1)    ==> MagicDamageTaken(5)
    DamageTaken(5 physical=1) ==> PhysicalDamageTaken(5)

DamageTaken() is also modified to no longer accept the "magic" and
"physical" named parameters, which are currently broken.

This allows for Ovale scripts to still check for specific types of
damage taken by using the new conditions in a simple, future-proof
way.