### PR TITLE
Bugfix/assassination rogue fixes

### DIFF
--- a/dist/scripts/ovale_rogue_spells.lua
+++ b/dist/scripts/ovale_rogue_spells.lua
@@ -558,8 +558,10 @@ Define(perforated_veins_conduit 248)
   SpellDamageBuff(garrote subterfuge set=1.8 enabled=(hastalent(subterfuge_talent)))
   SpellDamageBuff(garrote 11327 set=1.8 enabled=(hastalent(subterfuge_talent)))
 
-  # Fix broken rupture_debuff definition inherited from Simulationcraft.
+  # Fix broken spell definitions inherited from Simulationcraft.
   Define(rupture_debuff 1943)
+  Define(sepsis 328305)
+  SpellInfo(sepsis cd=90 energy=25 combopoints=-1))
 
   SpellRequire(slice_and_dice unusable set=1 enabled=(buffremains(slice_and_dice)>(combopoints()+1)*6))
 

--- a/dist/scripts/ovale_rogue_spells.lua
+++ b/dist/scripts/ovale_rogue_spells.lua
@@ -561,7 +561,7 @@ Define(perforated_veins_conduit 248)
   # Fix broken spell definitions inherited from Simulationcraft.
   Define(rupture_debuff 1943)
   Define(sepsis 328305)
-  SpellInfo(sepsis cd=90 energy=25 combopoints=-1))
+  SpellInfo(sepsis cd=90 energy=25 combopoints=-1)
 
   SpellRequire(slice_and_dice unusable set=1 enabled=(buffremains(slice_and_dice)>(combopoints()+1)*6))
 

--- a/src/scripts/ovale_rogue_spells.ts
+++ b/src/scripts/ovale_rogue_spells.ts
@@ -565,7 +565,7 @@ Define(perforated_veins_conduit 248)
   # Fix broken spell definitions inherited from Simulationcraft.
   Define(rupture_debuff 1943)
   Define(sepsis 328305)
-  SpellInfo(sepsis cd=90 energy=25 combopoints=-1))
+  SpellInfo(sepsis cd=90 energy=25 combopoints=-1)
 
   SpellRequire(slice_and_dice unusable set=1 enabled=(buffremains(slice_and_dice)>(combopoints()+1)*6))
 

--- a/src/scripts/ovale_rogue_spells.ts
+++ b/src/scripts/ovale_rogue_spells.ts
@@ -562,8 +562,10 @@ Define(perforated_veins_conduit 248)
   SpellDamageBuff(garrote subterfuge set=1.8 enabled=(hastalent(subterfuge_talent)))
   SpellDamageBuff(garrote 11327 set=1.8 enabled=(hastalent(subterfuge_talent)))
 
-  # Fix broken rupture_debuff definition inherited from Simulationcraft.
+  # Fix broken spell definitions inherited from Simulationcraft.
   Define(rupture_debuff 1943)
+  Define(sepsis 328305)
+  SpellInfo(sepsis cd=90 energy=25 combopoints=-1))
 
   SpellRequire(slice_and_dice unusable set=1 enabled=(buffremains(slice_and_dice)>(combopoints()+1)*6))
 


### PR DESCRIPTION
Additional fix for Night Fae Sepsis ability, which had the wrong spell ID.