### PR TITLE
Translate "apply_poison" in SimulationCraft profiles again.

### DIFF
--- a/dist/engine/data.lua
+++ b/dist/engine/data.lua
@@ -286,6 +286,11 @@ __exports.OvaleDataClass = __class(nil, {
                 [193357] = true,
                 [199603] = true,
                 [193359] = true
+            },
+            lethal_poison_buff = {
+                [2823] = true,
+                [8679] = true,
+                [315584] = true
             }
         }
         self.DEFAULT_SPELL_LIST = {}

--- a/dist/scripts/ovale_rogue.lua
+++ b/dist/scripts/ovale_rogue.lua
@@ -173,6 +173,7 @@ AddFunction assassinationprecombatmainpostconditions
 AddFunction assassinationprecombatshortcdactions
 {
  #apply_poison
+ if BuffRemaining(lethal_poison_buff) < 1200 Spell(deadly_poison)
  #flask
  #augmentation
  #food
@@ -879,6 +880,7 @@ AddFunction outlawprecombatmainpostconditions
 AddFunction outlawprecombatshortcdactions
 {
  #apply_poison
+ if BuffRemaining(lethal_poison_buff) < 1200 Spell(instant_poison)
  #flask
  #augmentation
  #food
@@ -1645,6 +1647,7 @@ AddFunction subtletystealth_cdscdpostconditions
 AddFunction subtletyprecombatmainactions
 {
  #apply_poison
+ if BuffRemaining(lethal_poison_buff) < 1200 Spell(instant_poison)
  #flask
  #augmentation
  #food

--- a/dist/scripts/ovale_rogue_spells.lua
+++ b/dist/scripts/ovale_rogue_spells.lua
@@ -520,6 +520,13 @@ Define(deeper_daggers_conduit 245)
 Define(perforated_veins_conduit 248)
     ]]
     code = code .. [[
+Define(instant_poison 315584)
+  SpellInfo(instant_poison duration=3600 gcd=0 offgcd=1)
+  SpellAddBuff(instant_poison instant_poison add=1)
+Define(wound_poison 8679)
+  SpellInfo(wound_poison duration=3600 gcd=0 offgcd=1)
+  SpellAddBuff(wound_poison wound_poison add=1)
+
   SpellInfo(garrote_exsanguinated duration=18)
   SpellInfo(rupture_exsanguinated duration=8) # TODO should be the same duration of the current rupture debuff
 

--- a/dist/simulationcraft/emiter.lua
+++ b/dist/simulationcraft/emiter.lua
@@ -441,15 +441,18 @@ __exports.Emiter = __class(nil, {
                 elseif className == "ROGUE" and action == "adrenaline_rush" then
                     conditionCode = "EnergyDeficit() > 1"
                 elseif className == "ROGUE" and action == "apply_poison" then
+                    local lethal = nil
                     if modifiers.lethal then
-                        local name = self.unparser:Unparse(modifiers.lethal)
-                        action = name .. "_poison"
-                        local buffName = "lethal_poison_buff"
-                        self:AddSymbol(annotation, buffName)
-                        conditionCode = format("BuffRemaining(%s) < 1200", buffName)
+                        lethal = self.unparser:Unparse(modifiers.lethal)
+                    elseif specialization == "assassination" then
+                        lethal = "deadly"
                     else
-                        isSpellAction = false
+                        lethal = "instant"
                     end
+                    action = lethal .. "_poison"
+                    local buffName = "lethal_poison_buff"
+                    self:AddSymbol(annotation, buffName)
+                    conditionCode = format("BuffRemaining(%s) < 1200", buffName)
                 elseif className == "ROGUE" and action == "cancel_autoattack" then
                     isSpellAction = false
                 elseif className == "ROGUE" and action == "premeditation" then

--- a/src/engine/data.ts
+++ b/src/engine/data.ts
@@ -429,6 +429,11 @@ export class OvaleDataClass {
             [SpellId.skull_and_crossbones]: true,
             [SpellId.true_bearing]: true,
         },
+        lethal_poison_buff: {
+            [SpellId.deadly_poison]: true,
+            [8679]: true,
+            [315584]: true,
+        },
     };
     constructor(private runner: Runner, ovaleDebug: OvaleDebugClass) {
         for (const [, useName] of pairs(STAT_USE_NAMES)) {

--- a/src/scripts/ovale_rogue.ts
+++ b/src/scripts/ovale_rogue.ts
@@ -176,6 +176,7 @@ AddFunction assassinationprecombatmainpostconditions
 AddFunction assassinationprecombatshortcdactions
 {
  #apply_poison
+ if BuffRemaining(lethal_poison_buff) < 1200 Spell(deadly_poison)
  #flask
  #augmentation
  #food
@@ -883,6 +884,7 @@ AddFunction outlawprecombatmainpostconditions
 AddFunction outlawprecombatshortcdactions
 {
  #apply_poison
+ if BuffRemaining(lethal_poison_buff) < 1200 Spell(instant_poison)
  #flask
  #augmentation
  #food
@@ -1650,6 +1652,7 @@ AddFunction subtletystealth_cdscdpostconditions
 AddFunction subtletyprecombatmainactions
 {
  #apply_poison
+ if BuffRemaining(lethal_poison_buff) < 1200 Spell(instant_poison)
  #flask
  #augmentation
  #food

--- a/src/scripts/ovale_rogue_spells.ts
+++ b/src/scripts/ovale_rogue_spells.ts
@@ -524,6 +524,13 @@ Define(perforated_veins_conduit 248)
 // END
 
     code += `
+Define(instant_poison 315584)
+  SpellInfo(instant_poison duration=3600 gcd=0 offgcd=1)
+  SpellAddBuff(instant_poison instant_poison add=1)
+Define(wound_poison 8679)
+  SpellInfo(wound_poison duration=3600 gcd=0 offgcd=1)
+  SpellAddBuff(wound_poison wound_poison add=1)
+
   SpellInfo(garrote_exsanguinated duration=18)
   SpellInfo(rupture_exsanguinated duration=8) # TODO should be the same duration of the current rupture debuff
 

--- a/src/simulationcraft/emiter.ts
+++ b/src/simulationcraft/emiter.ts
@@ -1362,18 +1362,21 @@ export class Emiter {
             } else if (className == "ROGUE" && action == "adrenaline_rush") {
                 conditionCode = "EnergyDeficit() > 1";
             } else if (className == "ROGUE" && action == "apply_poison") {
+                let lethal: string | undefined = undefined;
                 if (modifiers.lethal) {
-                    const name = this.unparser.Unparse(modifiers.lethal);
-                    action = `${name}_poison`;
-                    const buffName = "lethal_poison_buff";
-                    this.AddSymbol(annotation, buffName);
-                    conditionCode = format(
-                        "BuffRemaining(%s) < 1200",
-                        buffName
-                    );
+                    lethal = this.unparser.Unparse(modifiers.lethal);
+                } else if (specialization == "assassination") {
+                    lethal = "deadly";
                 } else {
-                    isSpellAction = false;
+                    lethal = "instant";
                 }
+                action = `${lethal}_poison`;
+                const buffName = "lethal_poison_buff";
+                this.AddSymbol(annotation, buffName);
+                conditionCode = format(
+                    "BuffRemaining(%s) < 1200",
+                    buffName
+                );
             } else if (className == "ROGUE" && action == "cancel_autoattack") {
                 isSpellAction = false;
             } else if (className == "ROGUE" && action == "premeditation") {


### PR DESCRIPTION
SimulationCraft relaxed the usage of "apply_poison" in rogue profiles to not require then "lethal" modifier that specified which lethal poison to apply.  Teach `simulationcraft/emiter.ts` to emit either "deadly_poison" or "instant_poison" depending on the rogue specialization in order to match the semantics in `simc:sc_rogue.cpp`.