### PR TITLE
Teach the Covenant class to manage its own ID <-> name mapping.

### DIFF
--- a/src/scripts/ovale_common.ts
+++ b/src/scripts/ovale_common.ts
@@ -9,12 +9,6 @@ export function registerCommon(OvaleScripts: OvaleScriptsClass) {
 Define(concentrated_flame_burn_debuff 295368)
 SpellInfo(concentrated_flame_burn_debuff duration=6)
 
-# Covenants
-Define(kyrian 1)
-Define(venthyr 2)
-Define(night_fae 3)
-Define(necrolord 4)
-
 `;
     OvaleScripts.RegisterScript(
         undefined,

--- a/src/states/covenant.ts
+++ b/src/states/covenant.ts
@@ -8,7 +8,7 @@ import {
     OvaleConditionClass,
     ReturnBoolean,
 } from "../engine/condition";
-import { pairs, ipairs, type, tostring, LuaArray, LuaObj, unpack } from "@wowts/lua";
+import { pairs, ipairs, tostring, LuaArray, LuaObj, unpack } from "@wowts/lua";
 import { OvaleDebugClass } from "../engine/debug";
 import { OptionUiGroup } from "../ui/acegui-helpers";
 import { gsub, lower } from "@wowts/string";

--- a/src/states/covenant.ts
+++ b/src/states/covenant.ts
@@ -8,7 +8,7 @@ import {
     OvaleConditionClass,
     ReturnBoolean,
 } from "../engine/condition";
-import { ipairs, LuaArray, LuaObj, unpack } from "@wowts/lua";
+import { pairs, ipairs, type, LuaArray, LuaObj, unpack } from "@wowts/lua";
 import { OvaleDebugClass } from "../engine/debug";
 import { OptionUiGroup } from "../ui/acegui-helpers";
 import { gsub, lower } from "@wowts/string";
@@ -85,8 +85,10 @@ export class Covenant {
         const [covenant] = unpack(positionalParameters);
         if (type(covenant) == "number") {
             return ReturnBoolean(this.covenantId === covenant);
-        } else {
+        } else if (type(covenant) == "string") {
             return ReturnBoolean(this.covenantId === COVENANT_ID_BY_NAME[covenant]);
+        } else {
+            return ReturnBoolean(false);
         }
     };
 }

--- a/src/states/covenant.ts
+++ b/src/states/covenant.ts
@@ -83,7 +83,7 @@ export class Covenant {
 
     private isCovenant: ConditionFunction = (positionalParameters) => {
         const [covenant] = unpack(positionalParameters);
-        if type(covenant) == "number" {
+        if (type(covenant) == "number") {
             return ReturnBoolean(this.covenantId === covenant);
         } else {
             return ReturnBoolean(this.covenantId === COVENANT_ID_BY_NAME[covenant]);

--- a/src/states/covenant.ts
+++ b/src/states/covenant.ts
@@ -2,7 +2,7 @@ import { OvaleClass } from "../Ovale";
 import aceEvent, { AceEvent } from "@wowts/ace_event-3.0";
 import { AceModule } from "@wowts/tsaddon";
 import { CovenantChosenEvent, C_Covenants } from "@wowts/wow-mock";
-import { AceEventHandler } from "../tools/tools";
+import { isNumber, isString, tostring, AceEventHandler } from "../tools/tools";
 import {
     ConditionFunction,
     OvaleConditionClass,
@@ -83,10 +83,11 @@ export class Covenant {
 
     private isCovenant: ConditionFunction = (positionalParameters) => {
         const [covenant] = unpack(positionalParameters);
-        if (type(covenant) == "number") {
+        if (isNumber(covenant)) {
             return ReturnBoolean(this.covenantId === covenant);
-        } else if (type(covenant) == "string") {
-            return ReturnBoolean(this.covenantId === COVENANT_ID_BY_NAME[covenant]);
+        } else if (isString(covenant)) {
+            const name = tostring(covenant);
+            return ReturnBoolean(this.covenantId === COVENANT_ID_BY_NAME[name]);
         } else {
             return ReturnBoolean(false);
         }

--- a/src/states/covenant.ts
+++ b/src/states/covenant.ts
@@ -54,7 +54,7 @@ export class Covenant {
         const ids = C_Covenants.GetCovenantIDs();
         for (const [, v] of ipairs(ids)) {
             const covenant = C_Covenants.GetCovenantData(v);
-            if (covenant and covenant.name and covenant.ID) {
+            if (covenant && covenant.name && covenant.ID) {
                 const [name] = gsub(lower(covenant.name), " ", "_");
                 COVENANT_ID_BY_NAME[name] = covenant.ID;
             }

--- a/src/states/covenant.ts
+++ b/src/states/covenant.ts
@@ -8,10 +8,13 @@ import {
     OvaleConditionClass,
     ReturnBoolean,
 } from "../engine/condition";
-import { ipairs, LuaArray, unpack } from "@wowts/lua";
+import { ipairs, LuaArray, LuaObj, unpack } from "@wowts/lua";
 import { OvaleDebugClass } from "../engine/debug";
 import { OptionUiGroup } from "../ui/acegui-helpers";
+import { gsub, lower } from "@wowts/string";
 import { concat, insert } from "@wowts/table";
+
+const COVENANT_ID_BY_NAME: LuaObj<number> = {};
 
 export class Covenant {
     private module: AceModule & AceEvent;
@@ -26,12 +29,12 @@ export class Covenant {
                 multiline: 25,
                 width: "full",
                 get: () => {
-                    const ids = C_Covenants.GetCovenantIDs();
                     const output: LuaArray<string> = {};
-                    for (const [, v] of ipairs(ids)) {
-                        const covenant = C_Covenants.GetCovenantData(v);
-                        if (covenant) {
-                            insert(output, `${covenant.name}: ${covenant.ID}`);
+                    for (const [k, v] of pairs(COVENANT_ID_BY_NAME)) {
+                        if (this.covenantId == v) {
+                            insert(output, `${k}: ${v} (active)`);
+                        } else {
+                            insert(output, `${k}: ${v}`);
                         }
                     }
                     return concat(output, "\n");
@@ -48,6 +51,14 @@ export class Covenant {
             aceEvent
         );
         debug.defaultOptions.args["covenant"] = this.debugOptions;
+        const ids = C_Covenants.GetCovenantIDs();
+        for (const [, v] of ipairs(ids)) {
+            const covenant = C_Covenants.GetCovenantData(v);
+            if (covenant and covenant.name and covenant.ID) {
+                const [name] = gsub(lower(covenant.name), " ", "_");
+                COVENANT_ID_BY_NAME[name] = covenant.ID;
+            }
+        }
     }
 
     public registerConditions(condition: OvaleConditionClass) {
@@ -71,7 +82,11 @@ export class Covenant {
     };
 
     private isCovenant: ConditionFunction = (positionalParameters) => {
-        const [covenantId] = unpack(positionalParameters);
-        return ReturnBoolean(this.covenantId === covenantId);
+        const [covenant] = unpack(positionalParameters);
+        if type(covenant) == "number" {
+            return ReturnBoolean(this.covenantId === covenant);
+        } else {
+            return ReturnBoolean(this.covenantId === COVENANT_ID_BY_NAME[covenant]);
+        }
     };
 }

--- a/src/states/covenant.ts
+++ b/src/states/covenant.ts
@@ -2,13 +2,13 @@ import { OvaleClass } from "../Ovale";
 import aceEvent, { AceEvent } from "@wowts/ace_event-3.0";
 import { AceModule } from "@wowts/tsaddon";
 import { CovenantChosenEvent, C_Covenants } from "@wowts/wow-mock";
-import { isNumber, isString, tostring, AceEventHandler } from "../tools/tools";
+import { isNumber, isString, AceEventHandler } from "../tools/tools";
 import {
     ConditionFunction,
     OvaleConditionClass,
     ReturnBoolean,
 } from "../engine/condition";
-import { pairs, ipairs, type, LuaArray, LuaObj, unpack } from "@wowts/lua";
+import { pairs, ipairs, type, tostring, LuaArray, LuaObj, unpack } from "@wowts/lua";
 import { OvaleDebugClass } from "../engine/debug";
 import { OptionUiGroup } from "../ui/acegui-helpers";
 import { gsub, lower } from "@wowts/string";


### PR DESCRIPTION
Enumerate all of the covenents and their corresponding IDs in a
COVENENT_ID_BY_NAME table and allow using names with the
IsCovenant() condition.

Modify the IsCovenant() condition to accept either a number or a
string for the parameter name.

This removes the need for the defintions in scripts/ovale_common
for `kyrian`, `venthyr`, `night_fae`, and `necrolord`, as these
strings can be used directly by IsCovenant().