### PR TITLE
Remove bitrotted and likely incorrect code regarding "nocd".

### DIFF
--- a/src/engine/ast.ts
+++ b/src/engine/ast.ts
@@ -452,7 +452,6 @@ export interface NodeActionResult extends BaseNodeValue {
         nored?: FlattenParameterValue;
         help?: FlattenParameterValue;
         pool_resource?: FlattenParameterValue;
-        nocd?: FlattenParameterValue;
         flash?: FlattenParameterValue;
     };
 }

--- a/src/engine/data.ts
+++ b/src/engine/data.ts
@@ -168,7 +168,6 @@ export interface SpellInfoValues extends Powers {
     interrupt?: number;
     add_duration?: number;
     add_cd?: number;
-    // nocd?:number;
     // flash?:boolean;
     // target?:string;
     // soundtime?:number;

--- a/src/ui/Frame.ts
+++ b/src/ui/Frame.ts
@@ -367,16 +367,7 @@ class OvaleFrame extends AceGUI.WidgetContainerBase {
             ) {
                 start = this.ovaleFuture.next.nextCast;
             }
-            if (
-                start &&
-                element.options &&
-                isNumber(element.options.nocd) &&
-                now < start - element.options.nocd
-            ) {
-                icons[1].Update(element, undefined);
-            } else {
-                icons[1].Update(element, start);
-            }
+            icons[1].Update(element, start);
             if (element.actionType == "spell") {
                 action.spellId = element.actionId;
             } else {
@@ -420,7 +411,6 @@ class OvaleFrame extends AceGUI.WidgetContainerBase {
             }
             // if (
             //     node.namedParams.size != "small" &&
-            //     !node.namedParams.nocd &&
             //     profile.apparence.predictif
             // ) {
             //     if (start) {


### PR DESCRIPTION
At one point, it may have been set as a paramter to AddIcon to
ignore the cooldown of the spell being displayed, but that hasn't
been used in at least 12 years, and the usage of "nocd" somehow
changed over time without any documentation on the new semantics.

Removing it to make the remaining codepath slightly clearer.