### PR TITLE
Remove unnecessary use of "tostring".

### DIFF
--- a/src/states/covenant.ts
+++ b/src/states/covenant.ts
@@ -2,7 +2,7 @@ import { OvaleClass } from "../Ovale";
 import aceEvent, { AceEvent } from "@wowts/ace_event-3.0";
 import { AceModule } from "@wowts/tsaddon";
 import { CovenantChosenEvent, C_Covenants } from "@wowts/wow-mock";
-import { isNumber, isString, AceEventHandler } from "../tools/tools";
+import { isNumber, AceEventHandler } from "../tools/tools";
 import {
     ConditionFunction,
     OvaleConditionClass,
@@ -83,13 +83,13 @@ export class Covenant {
 
     private isCovenant: ConditionFunction = (positionalParameters) => {
         const [covenant] = unpack(positionalParameters);
+        if (!covenant) return [];
+        let id: number | undefined;
         if (isNumber(covenant)) {
-            return ReturnBoolean(this.covenantId === covenant);
-        } else if (isString(covenant)) {
-            const name = covenant as string;
-            return ReturnBoolean(this.covenantId === COVENANT_ID_BY_NAME[name]);
+            id = covenant;
         } else {
-            return ReturnBoolean(false);
+            id = COVENANT_ID_BY_NAME[covenant as string]
         }
+        return ReturnBoolean(this.covenantId === id);
     };
 }

--- a/src/states/covenant.ts
+++ b/src/states/covenant.ts
@@ -8,7 +8,7 @@ import {
     OvaleConditionClass,
     ReturnBoolean,
 } from "../engine/condition";
-import { pairs, ipairs, tostring, LuaArray, LuaObj, unpack } from "@wowts/lua";
+import { pairs, ipairs, LuaArray, LuaObj, unpack } from "@wowts/lua";
 import { OvaleDebugClass } from "../engine/debug";
 import { OptionUiGroup } from "../ui/acegui-helpers";
 import { gsub, lower } from "@wowts/string";
@@ -86,7 +86,7 @@ export class Covenant {
         if (isNumber(covenant)) {
             return ReturnBoolean(this.covenantId === covenant);
         } else if (isString(covenant)) {
-            const name = tostring(covenant);
+            const name = covenant as string;
             return ReturnBoolean(this.covenantId === COVENANT_ID_BY_NAME[name]);
         } else {
             return ReturnBoolean(false);


### PR DESCRIPTION
There is no need to call "tostring" after we've checked that it's
already a string. Simply use "as string" to help with type
assertion.

This commit is a small optimization, but is mostly to test that
my development environment works correctly to use nodejs
to turn TypeScript into Lua correctly.