### PR TITLE
fix: register correct callback to AceTimer:ScheduleTimer()

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@wowts/ace_gui-3.0": "^1.2.0",
         "@wowts/ace_locale-3.0": "^1.0.0",
         "@wowts/ace_serializer-3.0": "^1.1.0",
-        "@wowts/ace_timer-3.0": "^2.2.0",
+        "@wowts/ace_timer-3.0": "^2.4.0",
         "@wowts/bit": "^1.0.0",
         "@wowts/callback_handler-1.0": "^1.0.0",
         "@wowts/coroutine": "^1.1.0",

--- a/src/ui/Version.ts
+++ b/src/ui/Version.ts
@@ -106,7 +106,7 @@ export class OvaleVersionClass {
             if (channel) {
                 this.module.SendCommMessage(MSG_PREFIX, message, channel);
             }
-            self_timer = this.module.ScheduleTimer("PrintVersionCheck", 3);
+            self_timer = this.module.ScheduleTimer(this.PrintVersionCheck, 3, this);
         }
     }
     PrintVersionCheck() {

--- a/src/ui/Version.ts
+++ b/src/ui/Version.ts
@@ -106,10 +106,11 @@ export class OvaleVersionClass {
             if (channel) {
                 this.module.SendCommMessage(MSG_PREFIX, message, channel);
             }
-            self_timer = this.module.ScheduleTimer(this.PrintVersionCheck, 3, this);
+            self_timer = this.module.ScheduleTimer(this.printVersionCheck, 3);
         }
     }
-    PrintVersionCheck() {
+
+    private printVersionCheck = () => {
         if (next(self_userVersion)) {
             wipe(self_printTable);
             for (const [sender, userVersion] of pairs(self_userVersion)) {
@@ -126,5 +127,5 @@ export class OvaleVersionClass {
             this.tracer.Print(">>> No other Ovale users present.");
         }
         self_timer = undefined;
-    }
+    };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -940,10 +940,10 @@
     "@wowts/tsaddon" "^1.1.2"
     "@wowts/tslib" "^1.1.0"
 
-"@wowts/ace_timer-3.0@^2.2.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@wowts/ace_timer-3.0/-/ace_timer-3.0-2.3.0.tgz#6cbbdbd38f713a9639685e2a1b0b3bde67ac2253"
-  integrity sha512-Hl0QuUxwLLShM6MyuNQ3OfbHmAcb8N5pOm3u7w6rYwYfgpHrnhn+r4a5wx0NG2d/fpe08snDvy2pN+Rrdc6ASg==
+"@wowts/ace_timer-3.0@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@wowts/ace_timer-3.0/-/ace_timer-3.0-2.4.0.tgz#9822476e3102b13ff6e83e30d245c18676896f90"
+  integrity sha512-OhEqHyw87px++rtBBaOhEJeylxURII0D1WZc72KTrdshnIytYvZ65uXJmK97y+wJ3VfDjzqGlU+bdEtSXsjJ5A==
   dependencies:
     "@wowts/lua" "^1.3.0"
     "@wowts/tsaddon" "^1.1.2"


### PR DESCRIPTION
AceTimer:ScheduleTimer() expects "PrintVersionCheck" to be a method
of "this.module", but no such method exists.

Use the correct function "this.PrintVersionCheck" and pass "this"
as a parameter to the function so that the method is called on the
correct object.

This fixes "/ovale ping" to allow checking for other users of Ovale
in the group or in the guild (if not in a group).