### PR TITLE
fix: show cooldown frame if a cooldown is active

### DIFF
--- a/src/ui/Icon.ts
+++ b/src/ui/Icon.ts
@@ -222,10 +222,10 @@ export class OvaleIcon {
                     cd.SetDrawEdge(false);
                     cd.SetSwipeColor(0, 0, 0, 0.8);
                     cd.SetCooldown(start, duration);
-                    cd.Show();
                 }
+                cd.Show();
             } else {
-                this.cd.Hide();
+                cd.Hide();
             }
             this.icone.Show();
             this.icone.SetTexture(element.actionTexture);


### PR DESCRIPTION
Always show the cooldown frame if the icon is displaying an action
that has a cooldown.  The frame's Show() method was not being
triggered when the icon was showing a texture again.

This fixes issue #739.