### PR TITLE
Spells are usable only if they meet all of their power requirements

### DIFF
--- a/src/engine/best-action.ts
+++ b/src/engine/best-action.ts
@@ -326,7 +326,7 @@ export class OvaleBestActionClass {
                 if (timeToPower > timeToCd) {
                     result.actionResourceExtend = timeToPower - timeToCd;
                     this.tracer.Log(
-                        "Spell ID '%s' requires an extra %fs for primary resource.",
+                        "Spell ID '%s' requires an extra %f seconds for power requirements.",
                         spellId,
                         result.actionResourceExtend
                     );

--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -271,7 +271,6 @@ export class IoC {
             this.profiler,
             this.data,
             this.baseState,
-            this.paperDoll,
             this.spellBook,
             combat
         );

--- a/src/states/Spells.ts
+++ b/src/states/Spells.ts
@@ -175,7 +175,7 @@ export class OvaleSpellsClass implements StateModule {
                 isUsable = false;
             }
             if (isUsable) {
-                noMana = !this.power.hasPowerFor(si, atTime);
+                noMana = !this.power.hasPowerFor(spellId, atTime, targetGUID);
                 if (noMana) {
                     isUsable = false;
                     this.tracer.Log(


### PR DESCRIPTION
These commits will cause a spell to not be suggested if their
power requirements cannot be met simply by waiting, e.g., chi,
holypower, combopoints, runicpower, etc.

This will cause most scripts to correctly fall through to other
spells which can be cast instead of suggesting a spell that is
waiting on resources.