### PR TITLE
fix: 'extraPower' parameter of TimeToPower() not used correctly

### DIFF
--- a/src/engine/ast.ts
+++ b/src/engine/ast.ts
@@ -857,7 +857,8 @@ export interface AstActionNode
         | "usable"
         | "target"
         | "offgcd"
-        | "extra_amount"
+        | "extra_energy"
+        | "extra_focus"
         | "texture"
     > {
     name: ActionType;
@@ -875,7 +876,8 @@ const checkActionParameters: NamedParametersCheck<AstActionNode> = {
     target: true,
     usable: true,
     offgcd: true,
-    extra_amount: true,
+    extra_energy: true,
+    extra_focus: true,
     texture: true,
 };
 

--- a/src/engine/best-action.ts
+++ b/src/engine/best-action.ts
@@ -292,8 +292,6 @@ export class OvaleBestActionClass {
                 result.actionTexture = `Interface\\Icons\\${si.texture}`;
             }
             if (result.actionCooldownStart && result.actionCooldownDuration) {
-                const extraPower =
-                    <number>element.cachedParams.named.extra_amount || 0;
                 // let seconds = OvaleSpells.GetTimeToSpell(spellId, atTime, targetGUID, extraPower);
                 const timeToCd =
                     (result.actionCooldownDuration > 0 &&
@@ -306,7 +304,7 @@ export class OvaleBestActionClass {
                     atTime,
                     targetGUID,
                     undefined,
-                    extraPower
+                    element.cachedParams.named
                 );
                 const runes = this.ovaleData.GetSpellInfoProperty(
                     spellId,


### PR DESCRIPTION
The commit 18d77148dfd32c04b7b2c9f559b0aca624edb8c2 did not
correctly handle the optional extraPower paramter of
Power:TimeToPower().

Generalize the parameter to be table whose keys "extra_energy" and
"extra_focus" are checked for extra amounts of the power type when
calculating the number of seconds until that power threshold is
met.

This removes the need to infer the pooled resource/power type.