### PR TITLE
refactor: condition cleanup

### DIFF
--- a/src/engine/condition.ts
+++ b/src/engine/condition.ts
@@ -301,24 +301,6 @@ export function ReturnBoolean(value: boolean): ConditionResult {
     return [];
 }
 
-export function TestValue(
-    start: number,
-    ending: number,
-    value: number | undefined,
-    origin: number | undefined,
-    rate: number | undefined
-): ConditionResult {
-    if (value === undefined || origin === undefined || rate === undefined) {
-        return [];
-    }
-    start = start || 0;
-    ending = ending || INFINITY;
-    if (start < ending) {
-        return [start, ending, value, origin, rate];
-    }
-    return [0, INFINITY, 0, 0, 0];
-}
-
 export function Compare(value: number): ConditionResult {
-    return TestValue(0, INFINITY, value, 0, 0);
+    return ReturnConstant(value);
 }

--- a/src/engine/condition.ts
+++ b/src/engine/condition.ts
@@ -300,7 +300,3 @@ export function ReturnBoolean(value: boolean): ConditionResult {
     if (value) return [0, INFINITY];
     return [];
 }
-
-export function Compare(value: number): ConditionResult {
-    return ReturnConstant(value);
-}

--- a/src/engine/condition.ts
+++ b/src/engine/condition.ts
@@ -271,19 +271,6 @@ export function ParseCondition(
     return [target, filter, mine];
 }
 
-export function TestBoolean(a: boolean, yesno: "yes" | "no"): ConditionResult {
-    if (!yesno || yesno == "yes") {
-        if (a) {
-            return [0, INFINITY];
-        }
-    } else {
-        if (!a) {
-            return [0, INFINITY];
-        }
-    }
-    return [];
-}
-
 export function ReturnValue(
     value: number,
     origin: number,
@@ -332,8 +319,6 @@ export function TestValue(
     return [0, INFINITY, 0, 0, 0];
 }
 
-export function Compare(
-    value: number
-): ConditionResult {
+export function Compare(value: number): ConditionResult {
     return TestValue(0, INFINITY, value, 0, 0);
 }

--- a/src/engine/condition.ts
+++ b/src/engine/condition.ts
@@ -38,20 +38,6 @@ export type ConditionAction = (
     result: AstNodeSnapshot
 ) => void;
 
-export type ComparatorId = "atleast" | "atmost" | "equal" | "less" | "more";
-
-const COMPARATOR: { [k in ComparatorId]: boolean } = {
-    atleast: true,
-    atmost: true,
-    equal: true,
-    less: true,
-    more: true,
-};
-
-export function isComparator(token: string): token is ComparatorId {
-    return COMPARATOR[token as ComparatorId] !== undefined;
-}
-
 interface NumberParameterInfo<Optional = boolean> {
     type: "number";
     name: string;
@@ -333,61 +319,21 @@ export function TestValue(
     ending: number,
     value: number | undefined,
     origin: number | undefined,
-    rate: number | undefined,
-    comparator?: string | undefined,
-    limit?: number | undefined
+    rate: number | undefined
 ): ConditionResult {
     if (value === undefined || origin === undefined || rate === undefined) {
         return [];
     }
     start = start || 0;
     ending = ending || INFINITY;
-    if (!comparator) {
-        if (start < ending) {
-            return [start, ending, value, origin, rate];
-        } else {
-            return [0, INFINITY, 0, 0, 0];
-        }
-    } else if (!isComparator(comparator)) {
-        return [];
-    } else if (!limit) {
-        return [];
-    } else if (rate == 0) {
-        if (
-            (comparator == "less" && value < limit) ||
-            (comparator == "atmost" && value <= limit) ||
-            (comparator == "equal" && value == limit) ||
-            (comparator == "atleast" && value >= limit) ||
-            (comparator == "more" && value > limit)
-        ) {
-            return [start, ending];
-        }
-    } else if (
-        (comparator == "less" && rate > 0) ||
-        (comparator == "atmost" && rate > 0) ||
-        (comparator == "atleast" && rate < 0) ||
-        (comparator == "more" && rate < 0)
-    ) {
-        const t = (limit - value) / rate + origin;
-        ending = (ending < t && ending) || t;
-        return [start, ending];
-    } else if (
-        (comparator == "less" && rate < 0) ||
-        (comparator == "atmost" && rate < 0) ||
-        (comparator == "atleast" && rate > 0) ||
-        (comparator == "more" && rate > 0)
-    ) {
-        const t = (limit - value) / rate + origin;
-        start = (start > t && start) || t;
-        return [start, INFINITY];
+    if (start < ending) {
+        return [start, ending, value, origin, rate];
     }
-    return [];
+    return [0, INFINITY, 0, 0, 0];
 }
 
 export function Compare(
-    value: number,
-    comparator: string | undefined,
-    limit: number | undefined
+    value: number
 ): ConditionResult {
-    return TestValue(0, INFINITY, value, 0, 0, comparator, limit);
+    return TestValue(0, INFINITY, value, 0, 0);
 }

--- a/src/scripts/ovale_warrior.ts
+++ b/src/scripts/ovale_warrior.ts
@@ -44,7 +44,7 @@ AddFunction armsgetinmeleerange
  if checkboxon(opt_melee_range) and not inflighttotarget(charge) and not inflighttotarget(heroic_leap) and not target.inrange(pummel)
  {
   if target.inrange(charge) spell(charge)
-  if spellcharges(charge) == 0 and target.distance(atleast 8) and target.distance(atmost 40) spell(heroic_leap)
+  if spellcharges(charge) == 0 and target.distance() >= 8 and target.distance() <= 40 spell(heroic_leap)
   texture(misc_arrowlup help=(l(not_in_melee_range)))
  }
 }
@@ -540,7 +540,7 @@ AddFunction furygetinmeleerange
  if checkboxon(opt_melee_range) and not inflighttotarget(charge) and not inflighttotarget(heroic_leap) and not target.inrange(pummel)
  {
   if target.inrange(charge) spell(charge)
-  if spellcharges(charge) == 0 and target.distance(atleast 8) and target.distance(atmost 40) spell(heroic_leap)
+  if spellcharges(charge) == 0 and target.distance() >= 8 and target.distance() <= 40 spell(heroic_leap)
   texture(misc_arrowlup help=(l(not_in_melee_range)))
  }
 }
@@ -651,7 +651,7 @@ AddFunction furyprecombatcdpostconditions
 AddFunction furymovementmainactions
 {
  #heroic_leap
- if checkboxon(opt_melee_range) and target.distance(atleast 8) and target.distance(atmost 40) spell(heroic_leap)
+ if checkboxon(opt_melee_range) and target.distance() >= 8 and target.distance() <= 40 spell(heroic_leap)
 }
 
 AddFunction furymovementmainpostconditions
@@ -664,7 +664,7 @@ AddFunction furymovementshortcdactions
 
 AddFunction furymovementshortcdpostconditions
 {
- checkboxon(opt_melee_range) and target.distance(atleast 8) and target.distance(atmost 40) and spell(heroic_leap)
+ checkboxon(opt_melee_range) and target.distance() >= 8 and target.distance() <= 40 and spell(heroic_leap)
 }
 
 AddFunction furymovementcdactions
@@ -673,7 +673,7 @@ AddFunction furymovementcdactions
 
 AddFunction furymovementcdpostconditions
 {
- checkboxon(opt_melee_range) and target.distance(atleast 8) and target.distance(atmost 40) and spell(heroic_leap)
+ checkboxon(opt_melee_range) and target.distance() >= 8 and target.distance() <= 40 and spell(heroic_leap)
 }
 
 ### actions.default
@@ -688,7 +688,7 @@ AddFunction fury_defaultmainactions
  unless target.distance() > 5 and furymovementmainpostconditions()
  {
   #heroic_leap,if=(raid_event.movement.distance>25&raid_event.movement.in>45)
-  if target.distance() > 25 and 600 > 45 and { checkboxon(opt_melee_range) and target.distance(atleast 8) and target.distance(atmost 40) } spell(heroic_leap)
+  if target.distance() > 25 and 600 > 45 and { checkboxon(opt_melee_range) and target.distance() >= 8 and target.distance() <= 40 } spell(heroic_leap)
   #rampage,if=cooldown.recklessness.remains<3&talent.reckless_abandon.enabled
   if spellcooldown(recklessness) < 3 and hastalent(reckless_abandon_talent) spell(rampage)
   #whirlwind,if=spell_targets.whirlwind>1&!buff.meat_cleaver.up|raid_event.adds.in<gcd&!buff.meat_cleaver.up
@@ -715,7 +715,7 @@ AddFunction fury_defaultshortcdactions
   #run_action_list,name=movement,if=movement.distance>5
   if target.distance() > 5 furymovementshortcdactions()
 
-  unless target.distance() > 5 and furymovementshortcdpostconditions() or target.distance() > 25 and 600 > 45 and { checkboxon(opt_melee_range) and target.distance(atleast 8) and target.distance(atmost 40) } and spell(heroic_leap) or spellcooldown(recklessness) < 3 and hastalent(reckless_abandon_talent) and spell(rampage)
+  unless target.distance() > 5 and furymovementshortcdpostconditions() or target.distance() > 25 and 600 > 45 and { checkboxon(opt_melee_range) and target.distance() >= 8 and target.distance() <= 40 } and spell(heroic_leap) or spellcooldown(recklessness) < 3 and hastalent(reckless_abandon_talent) and spell(rampage)
   {
    #recklessness,if=gcd.remains=0&((buff.bloodlust.up|talent.anger_management.enabled|raid_event.adds.in>10)|target.time_to_die>100|(talent.massacre.enabled&target.health.pct<35)|target.health.pct<20|target.time_to_die<15&raid_event.adds.in>10)&(spell_targets.whirlwind=1|buff.meat_cleaver.up)
    if not gcdremaining() > 0 and { buffpresent(bloodlust) or hastalent(anger_management_talent_fury) or 600 > 10 or target.timetodie() > 100 or hastalent(massacre_talent) and target.healthpercent() < 35 or target.healthpercent() < 20 or target.timetodie() < 15 and 600 > 10 } and { enemies() == 1 or buffpresent(meat_cleaver) } spell(recklessness)
@@ -733,7 +733,7 @@ AddFunction fury_defaultshortcdactions
 
 AddFunction fury_defaultshortcdpostconditions
 {
- checkboxon(opt_melee_range) and target.inrange(charge) and not target.inrange(pummel) and spell(charge) or target.distance() > 5 and furymovementshortcdpostconditions() or target.distance() > 25 and 600 > 45 and { checkboxon(opt_melee_range) and target.distance(atleast 8) and target.distance(atmost 40) } and spell(heroic_leap) or spellcooldown(recklessness) < 3 and hastalent(reckless_abandon_talent) and spell(rampage) or { enemies() > 1 and not buffpresent(meat_cleaver) or 600 < gcd() and not buffpresent(meat_cleaver) } and spell(whirlwind_fury) or buffpresent(recklessness) and spell(berserking) or furysingle_targetshortcdpostconditions()
+ checkboxon(opt_melee_range) and target.inrange(charge) and not target.inrange(pummel) and spell(charge) or target.distance() > 5 and furymovementshortcdpostconditions() or target.distance() > 25 and 600 > 45 and { checkboxon(opt_melee_range) and target.distance() >= 8 and target.distance() <= 40 } and spell(heroic_leap) or spellcooldown(recklessness) < 3 and hastalent(reckless_abandon_talent) and spell(rampage) or { enemies() > 1 and not buffpresent(meat_cleaver) or 600 < gcd() and not buffpresent(meat_cleaver) } and spell(whirlwind_fury) or buffpresent(recklessness) and spell(berserking) or furysingle_targetshortcdpostconditions()
 }
 
 AddFunction fury_defaultcdactions
@@ -745,7 +745,7 @@ AddFunction fury_defaultcdactions
   #run_action_list,name=movement,if=movement.distance>5
   if target.distance() > 5 furymovementcdactions()
 
-  unless target.distance() > 5 and furymovementcdpostconditions() or target.distance() > 25 and 600 > 45 and { checkboxon(opt_melee_range) and target.distance(atleast 8) and target.distance(atmost 40) } and spell(heroic_leap)
+  unless target.distance() > 5 and furymovementcdpostconditions() or target.distance() > 25 and 600 > 45 and { checkboxon(opt_melee_range) and target.distance() >= 8 and target.distance() <= 40 } and spell(heroic_leap)
   {
    #potion
    if checkboxon(opt_use_consumables) and target.classification(worldboss) item(potion_of_phantom_fire_item usable=1)
@@ -779,7 +779,7 @@ AddFunction fury_defaultcdactions
 
 AddFunction fury_defaultcdpostconditions
 {
- checkboxon(opt_melee_range) and target.inrange(charge) and not target.inrange(pummel) and spell(charge) or target.distance() > 5 and furymovementcdpostconditions() or target.distance() > 25 and 600 > 45 and { checkboxon(opt_melee_range) and target.distance(atleast 8) and target.distance(atmost 40) } and spell(heroic_leap) or spellcooldown(recklessness) < 3 and hastalent(reckless_abandon_talent) and spell(rampage) or not gcdremaining() > 0 and { buffpresent(bloodlust) or hastalent(anger_management_talent_fury) or 600 > 10 or target.timetodie() > 100 or hastalent(massacre_talent) and target.healthpercent() < 35 or target.healthpercent() < 20 or target.timetodie() < 15 and 600 > 10 } and { enemies() == 1 or buffpresent(meat_cleaver) } and spell(recklessness) or { enemies() > 1 and not buffpresent(meat_cleaver) or 600 < gcd() and not buffpresent(meat_cleaver) } and spell(whirlwind_fury) or buffpresent(recklessness) and spell(berserking) or buffexpires(recklessness) and target.debuffexpires(siegebreaker_debuff) and isenraged() and spell(bag_of_tricks) or furysingle_targetcdpostconditions()
+ checkboxon(opt_melee_range) and target.inrange(charge) and not target.inrange(pummel) and spell(charge) or target.distance() > 5 and furymovementcdpostconditions() or target.distance() > 25 and 600 > 45 and { checkboxon(opt_melee_range) and target.distance() >= 8 and target.distance() <= 40 } and spell(heroic_leap) or spellcooldown(recklessness) < 3 and hastalent(reckless_abandon_talent) and spell(rampage) or not gcdremaining() > 0 and { buffpresent(bloodlust) or hastalent(anger_management_talent_fury) or 600 > 10 or target.timetodie() > 100 or hastalent(massacre_talent) and target.healthpercent() < 35 or target.healthpercent() < 20 or target.timetodie() < 15 and 600 > 10 } and { enemies() == 1 or buffpresent(meat_cleaver) } and spell(recklessness) or { enemies() > 1 and not buffpresent(meat_cleaver) or 600 < gcd() and not buffpresent(meat_cleaver) } and spell(whirlwind_fury) or buffpresent(recklessness) and spell(berserking) or buffexpires(recklessness) and target.debuffexpires(siegebreaker_debuff) and isenraged() and spell(bag_of_tricks) or furysingle_targetcdpostconditions()
 }
 
 ### Fury icons.
@@ -913,7 +913,7 @@ AddFunction protectiongetinmeleerange
  if checkboxon(opt_melee_range) and not inflighttotarget(intercept) and not inflighttotarget(heroic_leap) and not target.inrange(pummel)
  {
   if target.inrange(intercept) spell(intercept)
-  if spellcharges(intercept) == 0 and target.distance(atleast 8) and target.distance(atmost 40) spell(heroic_leap)
+  if spellcharges(intercept) == 0 and target.distance() >= 8 and target.distance() <= 40 spell(heroic_leap)
   texture(misc_arrowlup help=(l(not_in_melee_range)))
  }
 }

--- a/src/simulationcraft/definitions.ts
+++ b/src/simulationcraft/definitions.ts
@@ -190,8 +190,8 @@ export const CHARACTER_PROPERTY: LuaObj<string> = {
     // ["raid_event.adds.remains"]: "0", // TODO
     // ["raid_event.invulnerable.exists"]: "0", //TODO
     // ["raw_haste_pct"]: "SpellCastSpeedPercent()",
-    // ["rtb_list.any.5"]: "BuffCount(roll_the_bones_buff more 4)",
-    // ["rtb_list.any.6"]: "BuffCount(roll_the_bones_buff more 5)",
+    // ["rtb_list.any.5"]: "BuffCount(roll_the_bones_buff) > 4)",
+    // ["rtb_list.any.6"]: "BuffCount(roll_the_bones_buff) > 5)",
     // ["rune.deficit"]: "RuneDeficit()",
     // ["runic_power"]: "RunicPower()",
     // ["runic_power.deficit"]: "RunicPowerDeficit()",

--- a/src/simulationcraft/emiter.ts
+++ b/src/simulationcraft/emiter.ts
@@ -1345,9 +1345,9 @@ export class Emiter {
             } else if (className == "MAGE" && action == "ice_floes") {
                 conditionCode = "Speed() > 0";
             } else if (className == "MAGE" && action == "blast_wave") {
-                conditionCode = "target.Distance(less 8)";
+                conditionCode = "target.Distance() < 8";
             } else if (className == "MAGE" && action == "dragons_breath") {
-                conditionCode = "target.Distance(less 12)";
+                conditionCode = "target.Distance() < 12";
             } else if (className == "MAGE" && action == "arcane_blast") {
                 conditionCode = "Mana() > ManaCost(arcane_blast)";
             } else if (className == "MAGE" && action == "cone_of_cold") {
@@ -1521,7 +1521,7 @@ export class Emiter {
                 isSpellAction = false;
             } else if (className == "WARRIOR" && action == "heroic_leap") {
                 conditionCode =
-                    "CheckBoxOn(opt_melee_range) and target.Distance(atLeast 8) and target.Distance(atMost 40)";
+                    "CheckBoxOn(opt_melee_range) and target.Distance() >= 8 and target.Distance() <= 40";
             } else if (action == "auto_attack") {
                 bodyCode = `${camelSpecialization}GetInMeleeRange()`;
                 isSpellAction = false;

--- a/src/simulationcraft/generator.ts
+++ b/src/simulationcraft/generator.ts
@@ -260,7 +260,7 @@ export class Generator {
                 name: "war_stomp",
                 stun: 1,
                 order: 99,
-                range: "target.Distance(less 5)",
+                range: "target.Distance() < 5",
             });
         }
 
@@ -285,7 +285,7 @@ export class Generator {
                 insert(interrupts, {
                     name: "blinding_sleet",
                     disorient: 1,
-                    range: "target.Distance(less 12)",
+                    range: "target.Distance() < 12",
                     order: 20,
                 });
             }
@@ -307,7 +307,7 @@ export class Generator {
                 insert(interrupts, {
                     name: "chaos_nova",
                     stun: 1,
-                    range: "target.Distance(less 8)",
+                    range: "target.Distance() < 8",
                     order: 100,
                 });
                 insert(interrupts, {
@@ -376,14 +376,14 @@ export class Generator {
                     name: "incapacitating_roar",
                     incapacitate: 1,
                     order: 30,
-                    range: "target.Distance(less 10)",
+                    range: "target.Distance() < 10",
                 });
             }
             insert(interrupts, {
                 name: "typhoon",
                 knockback: 1,
                 order: 110,
-                range: "target.Distance(less 15)",
+                range: "target.Distance() < 15",
             });
             if (annotation.specialization == "feral") {
                 insert(interrupts, {
@@ -433,7 +433,7 @@ export class Generator {
                 name: "leg_sweep",
                 stun: 1,
                 order: 30,
-                range: "target.Distance(less 5)",
+                range: "target.Distance() < 5",
             });
         }
         if (annotation.rebuke == "PALADIN") {
@@ -459,7 +459,7 @@ export class Generator {
                     name: "blinding_light",
                     disorient: 1,
                     order: 50,
-                    range: "target.Distance(less 10)",
+                    range: "target.Distance() < 10",
                 });
             }
         }
@@ -526,7 +526,7 @@ export class Generator {
                     name: "sundering",
                     knockback: 1,
                     order: 20,
-                    range: "target.Distance(less 5)",
+                    range: "target.Distance() < 5",
                 });
             }
             insert(interrupts, {
@@ -556,7 +556,7 @@ export class Generator {
                 stun: 1,
                 worksOnBoss: 0,
                 order: 20,
-                range: "target.Distance(less 10)",
+                range: "target.Distance() < 10",
             });
             insert(interrupts, {
                 name: "storm_bolt",
@@ -921,7 +921,7 @@ export class Generator {
                     if CheckBoxOn(opt_melee_range) and not InFlightToTarget(%s) and not InFlightToTarget(heroic_leap) and not target.InRange(pummel)
                     {
                         if target.InRange(%s) Spell(%s)
-                        if SpellCharges(%s) == 0 and target.Distance(atLeast 8) and target.Distance(atMost 40) Spell(heroic_leap)
+                        if SpellCharges(%s) == 0 and target.Distance() >= 8 and target.Distance() <= 40 Spell(heroic_leap)
                         Texture(misc_arrowlup help=L(not_in_melee_range))
                     }
                 }

--- a/src/states/AzeriteArmor.ts
+++ b/src/states/AzeriteArmor.ts
@@ -196,13 +196,9 @@ export class OvaleAzeriteArmor {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const spellId = positionalParams[1];
         const value = this.TraitRank(spellId);
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
     private HasAzeriteTrait = (
         positionalParams: LuaArray<any>,

--- a/src/states/AzeriteArmor.ts
+++ b/src/states/AzeriteArmor.ts
@@ -24,9 +24,9 @@ import { OvaleDebugClass } from "../engine/debug";
 import { AceEventHandler } from "../tools/tools";
 import { OptionUiAll } from "../ui/acegui-helpers";
 import {
-    Compare,
     OvaleConditionClass,
     ReturnBoolean,
+    ReturnConstant,
 } from "../engine/condition";
 import { AstFunctionNode, NamedParametersOf } from "../engine/ast";
 
@@ -202,7 +202,7 @@ export class OvaleAzeriteArmor {
     ) => {
         const spellId = positionalParams[1];
         const value = this.TraitRank(spellId);
-        return Compare(value);
+        return ReturnConstant(value);
     };
     private HasAzeriteTrait = (
         positionalParams: LuaArray<any>,

--- a/src/states/AzeriteArmor.ts
+++ b/src/states/AzeriteArmor.ts
@@ -23,7 +23,11 @@ import { OvaleClass } from "../Ovale";
 import { OvaleDebugClass } from "../engine/debug";
 import { AceEventHandler } from "../tools/tools";
 import { OptionUiAll } from "../ui/acegui-helpers";
-import { Compare, OvaleConditionClass, TestBoolean } from "../engine/condition";
+import {
+    Compare,
+    OvaleConditionClass,
+    ReturnBoolean,
+} from "../engine/condition";
 import { AstFunctionNode, NamedParametersOf } from "../engine/ast";
 
 const azeriteSlots: LuaArray<boolean> = {
@@ -205,8 +209,8 @@ export class OvaleAzeriteArmor {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, yesno] = [positionalParams[1], positionalParams[2]];
+        const spellId = positionalParams[1];
         const value = this.HasTrait(spellId);
-        return TestBoolean(value, yesno);
+        return ReturnBoolean(value);
     };
 }

--- a/src/states/Equipment.ts
+++ b/src/states/Equipment.ts
@@ -30,7 +30,6 @@ import { OvaleDebugClass } from "../engine/debug";
 import { Profiler, OvaleProfilerClass } from "../engine/profiler";
 import { OptionUiAll } from "../ui/acegui-helpers";
 import {
-    Compare,
     ConditionFunction,
     ConditionResult,
     OvaleConditionClass,
@@ -605,7 +604,7 @@ export class OvaleEquipmentClass {
                 return ReturnValueBetween(start, ending, duration, start, -1);
             }
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     private itemCooldownDuration = (

--- a/src/states/Equipment.ts
+++ b/src/states/Equipment.ts
@@ -592,8 +592,6 @@ export class OvaleEquipmentClass {
 	 @name ItemCooldown
 	 @paramsig number or boolean
 	 @param id The item ID or the equipped slot name.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -607,29 +605,18 @@ export class OvaleEquipmentClass {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        let [itemId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        let itemId = positionalParams[1];
         if (itemId && type(itemId) != "number") {
             itemId = this.GetEquippedItemBySlotName(itemId);
         }
         if (itemId) {
             const [start, duration] = GetItemCooldown(itemId);
             if (start > 0 && duration > 0) {
-                return TestValue(
-                    start,
-                    start + duration,
-                    duration,
-                    start,
-                    -1,
-                    comparator,
-                    limit
-                );
+                const ending = start + duration;
+                return TestValue(start, ending, duration, start, -1);
             }
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     private itemCooldownDuration = (

--- a/src/states/Equipment.ts
+++ b/src/states/Equipment.ts
@@ -34,8 +34,8 @@ import {
     ConditionFunction,
     ConditionResult,
     OvaleConditionClass,
+    ReturnBoolean,
     ReturnConstant,
-    TestBoolean,
     TestValue,
 } from "../engine/condition";
 import { OvaleDataClass } from "../engine/data";
@@ -506,16 +506,13 @@ export class OvaleEquipmentClass {
 	 @name HasEquippedItem
 	 @paramsig boolean
 	 @param item Item to be checked whether it is equipped.
-	 @param yesno Optional. If yes, then return true if the item is equipped. If no, then return true if it isn't equipped.
-	     Default is yes.
-	     Valid values: yes, no.
      */
     private hasEquippedItem = (
         positionalParams: LuaArray<any>,
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [itemId, yesno] = [positionalParams[1], positionalParams[2]];
+        const itemId = positionalParams[1];
         let boolean = false;
         let slotId;
         if (type(itemId) == "number") {
@@ -532,15 +529,12 @@ export class OvaleEquipmentClass {
                 }
             }
         }
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /** Test if the player has a shield equipped.
 	 @name HasShield
 	 @paramsig boolean
-	 @param yesno Optional. If yes, then return true if a shield is equipped. If no, then return true if it isn't equipped.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @return A boolean value.
 	 @usage
 	 if HasShield() Spell(shield_wall)
@@ -550,19 +544,14 @@ export class OvaleEquipmentClass {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const yesno = positionalParams[1];
         const boolean = this.HasShield();
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /** Test if the player has a particular trinket equipped.
 	 @name HasTrinket
 	 @paramsig boolean
 	 @param id The item ID of the trinket or the name of an item list.
-	 @param yesno Optional. If yes, then return true if the trinket is equipped. If no, then return true if it isn't equipped.
-	     Default is yes.
-	     Valid values: yes, no.
-	 @return A boolean value.
 	 @usage
 	 ItemList(rune_of_reorigination 94532 95802 96546)
 	 if HasTrinket(rune_of_reorigination) and BuffPresent(rune_of_reorigination_buff)
@@ -573,7 +562,7 @@ export class OvaleEquipmentClass {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [trinketId, yesno] = [positionalParams[1], positionalParams[2]];
+        const trinketId = positionalParams[1];
         let boolean: boolean | undefined = undefined;
         if (type(trinketId) == "number") {
             boolean = this.HasTrinket(trinketId);
@@ -585,7 +574,7 @@ export class OvaleEquipmentClass {
                 }
             }
         }
-        return TestBoolean(boolean !== undefined, yesno);
+        return ReturnBoolean(boolean !== undefined);
     };
 
     /** Get the cooldown time in seconds of an item, e.g., trinket.

--- a/src/states/Equipment.ts
+++ b/src/states/Equipment.ts
@@ -36,7 +36,7 @@ import {
     OvaleConditionClass,
     ReturnBoolean,
     ReturnConstant,
-    TestValue,
+    ReturnValueBetween,
 } from "../engine/condition";
 import { OvaleDataClass } from "../engine/data";
 import { huge } from "@wowts/math";
@@ -602,7 +602,7 @@ export class OvaleEquipmentClass {
             const [start, duration] = GetItemCooldown(itemId);
             if (start > 0 && duration > 0) {
                 const ending = start + duration;
-                return TestValue(start, ending, duration, start, -1);
+                return ReturnValueBetween(start, ending, duration, start, -1);
             }
         }
         return Compare(0);

--- a/src/states/Stagger.ts
+++ b/src/states/Stagger.ts
@@ -226,8 +226,6 @@ export class OvaleStaggerClass implements StateModule {
 	 @name StaggerTick
      @paramsig number or boolean
      @param count Optional. Counts n amount of previous stagger ticks.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -243,12 +241,8 @@ export class OvaleStaggerClass implements StateModule {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [count, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[2],
-        ];
+        const count = positionalParams[1];
         const damage = this.LastTickDamage(count);
-        return Compare(damage, comparator, limit);
+        return Compare(damage);
     };
 }

--- a/src/states/Stagger.ts
+++ b/src/states/Stagger.ts
@@ -7,11 +7,11 @@ import { OvaleClass } from "../Ovale";
 import { StateModule } from "../engine/state";
 import { OvaleCombatClass } from "./combat";
 import {
-    Compare,
     ConditionFunction,
     ConditionResult,
     OvaleConditionClass,
     ParseCondition,
+    ReturnConstant,
     ReturnValueBetween,
 } from "../engine/condition";
 import { OvaleAuraClass } from "./Aura";
@@ -243,6 +243,6 @@ export class OvaleStaggerClass implements StateModule {
     ) => {
         const count = positionalParams[1];
         const damage = this.LastTickDamage(count);
-        return Compare(damage);
+        return ReturnConstant(damage);
     };
 }

--- a/src/states/Stance.ts
+++ b/src/states/Stance.ts
@@ -16,7 +16,7 @@ import { OvaleClass } from "../Ovale";
 import { OvaleProfilerClass, Profiler } from "../engine/profiler";
 import { OvaleDataClass } from "../engine/data";
 import { OptionUiAll } from "../ui/acegui-helpers";
-import { OvaleConditionClass, TestBoolean } from "../engine/condition";
+import { OvaleConditionClass, ReturnBoolean } from "../engine/condition";
 import { AstFunctionNode, NamedParametersOf } from "../engine/ast";
 
 const [druidCatForm] = GetSpellInfo(768);
@@ -124,9 +124,6 @@ export class OvaleStanceClass
 	 @name Stance
 	 @paramsig boolean
 	 @param stance The stance name or a number representing the stance index.
-	 @param yesno Optional. If yes, then return true if the player is in the given stance. If no, then return true otherwise.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @return A boolean value.
 	 @usage
 	 unless Stance(druid_bear_form) Spell(bear_form)
@@ -136,9 +133,9 @@ export class OvaleStanceClass
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [stance, yesno] = [positionalParams[1], positionalParams[2]];
+        const stance = positionalParams[1];
         const boolean = this.IsStance(stance, atTime);
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     private OnInitialize = () => {

--- a/src/states/Variables.ts
+++ b/src/states/Variables.ts
@@ -4,9 +4,9 @@ import { BaseState } from "./BaseState";
 import { OvaleDebugClass, Tracer } from "../engine/debug";
 import { OvaleCombatClass } from "./combat";
 import {
-    Compare,
     ConditionAction,
     OvaleConditionClass,
+    ReturnConstant,
 } from "../engine/condition";
 import { huge } from "@wowts/math";
 import {
@@ -130,7 +130,7 @@ export class Variables implements StateModule {
     ) => {
         const name = positionalParams[1];
         const value = this.GetState(name);
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /** Get the duration in seconds that the simulator was most recently in the named state.
@@ -147,7 +147,7 @@ export class Variables implements StateModule {
     ) => {
         const name = positionalParams[1];
         const value = this.GetStateDuration(name, atTime);
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     private setState: ConditionAction = (

--- a/src/states/Variables.ts
+++ b/src/states/Variables.ts
@@ -120,8 +120,6 @@ export class Variables implements StateModule {
 	 @name GetState
 	 @paramsig number or boolean
 	 @param name The name of the state variable.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The value of the state variable.
 	 @return A boolean value for the result of the comparison.
      */
@@ -130,21 +128,15 @@ export class Variables implements StateModule {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [name, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const name = positionalParams[1];
         const value = this.GetState(name);
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /** Get the duration in seconds that the simulator was most recently in the named state.
 	 @name GetStateDuration
 	 @paramsig number or boolean
 	 @param name The name of the state variable.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @return A boolean value for the result of the comparison.
      */
@@ -153,13 +145,9 @@ export class Variables implements StateModule {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [name, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const name = positionalParams[1];
         const value = this.GetStateDuration(name, atTime);
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     private setState: ConditionAction = (

--- a/src/states/Warlock.ts
+++ b/src/states/Warlock.ts
@@ -14,7 +14,7 @@ import { StateModule } from "../engine/state";
 import { OvaleAuraClass } from "./Aura";
 import { OvalePaperDollClass } from "./PaperDoll";
 import { OvaleSpellBookClass } from "./SpellBook";
-import { Compare, OvaleConditionClass } from "../engine/condition";
+import { OvaleConditionClass, ReturnConstant } from "../engine/condition";
 import { OvaleFutureClass } from "./Future";
 import { OvalePowerClass } from "./Power";
 import { AstFunctionNode, NamedParametersOf } from "../engine/ast";
@@ -234,7 +234,7 @@ export class OvaleWarlockClass implements StateModule {
                 impsSpawned = impsSpawned + 1;
             }
         }
-        return Compare(impsSpawned);
+        return ReturnConstant(impsSpawned);
     };
 
     private getDemonsCount = (
@@ -249,7 +249,7 @@ export class OvaleWarlockClass implements StateModule {
                 count = count + 1;
             }
         }
-        return Compare(count);
+        return ReturnConstant(count);
     };
 
     private demonDuration = (
@@ -259,7 +259,7 @@ export class OvaleWarlockClass implements StateModule {
     ) => {
         const creatureId = positionalParams[1];
         const value = this.getRemainingDemonDuration(creatureId, atTime);
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     private getRemainingDemonDuration(creatureId: number, atTime: number) {
@@ -344,6 +344,6 @@ export class OvaleWarlockClass implements StateModule {
         atTime: number
     ) => {
         const value = this.getTimeToShard(atTime);
-        return Compare(value);
+        return ReturnConstant(value);
     };
 }

--- a/src/states/Warlock.ts
+++ b/src/states/Warlock.ts
@@ -209,14 +209,10 @@ export class OvaleWarlockClass implements StateModule {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [ms, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const ms = positionalParams[1];
         const delay = (ms || 0) / 1000;
         let impsSpawned = 0;
-        // check for hand of guldan
+        // check for Hand of Guldan
         if (this.future.next.currentCast.spellId == SpellId.hand_of_guldan) {
             let soulshards = this.power.current.power["soulshards"] || 0;
             if (soulshards >= 3) {
@@ -238,7 +234,7 @@ export class OvaleWarlockClass implements StateModule {
                 impsSpawned = impsSpawned + 1;
             }
         }
-        return Compare(impsSpawned, comparator, limit);
+        return Compare(impsSpawned);
     };
 
     private getDemonsCount = (
@@ -246,18 +242,14 @@ export class OvaleWarlockClass implements StateModule {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [creatureId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const creatureId = positionalParams[1];
         let count = 0;
         for (const [, d] of pairs(this.demonsCount)) {
             if (d.finish >= atTime && d.id == creatureId) {
                 count = count + 1;
             }
         }
-        return Compare(count, comparator, limit);
+        return Compare(count);
     };
 
     private demonDuration = (
@@ -265,13 +257,9 @@ export class OvaleWarlockClass implements StateModule {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [creatureId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const creatureId = positionalParams[1];
         const value = this.getRemainingDemonDuration(creatureId, atTime);
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     private getRemainingDemonDuration(creatureId: number, atTime: number) {
@@ -355,8 +343,7 @@ export class OvaleWarlockClass implements StateModule {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const value = this.getTimeToShard(atTime);
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 }

--- a/src/states/combat.ts
+++ b/src/states/combat.ts
@@ -8,11 +8,11 @@ import { OvaleSpellBookClass } from "./SpellBook";
 import { LuaArray } from "@wowts/lua";
 import {
     OvaleConditionClass,
-    TestValue,
     Compare,
     ConditionFunction,
     ReturnBoolean,
     ReturnConstant,
+    ReturnValueBetween,
 } from "../engine/condition";
 import { huge as INFINITY } from "@wowts/math";
 import { AstFunctionNode, NamedParametersOf } from "../engine/ast";
@@ -155,7 +155,7 @@ export class OvaleCombatClass
         if (this.isInCombat(atTime)) {
             const state = this.GetState(atTime);
             const start = state.combatStartTime;
-            return TestValue(start, INFINITY, 0, start, 1);
+            return ReturnValueBetween(start, INFINITY, 0, start, 1);
         }
         return Compare(0);
     };

--- a/src/states/combat.ts
+++ b/src/states/combat.ts
@@ -14,7 +14,7 @@ import {
     ConditionFunction,
     ReturnConstant,
 } from "../engine/condition";
-import { huge } from "@wowts/math";
+import { huge as INFINITY } from "@wowts/math";
 import { AstFunctionNode, NamedParametersOf } from "../engine/ast";
 
 export class CombatState {
@@ -143,24 +143,22 @@ export class OvaleCombatClass
     /** Get the number of seconds elapsed since the player entered combat.
 	 @name TimeInCombat
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if TimeInCombat(more 5) Spell(bloodlust)
+	 if TimeInCombat() > 5 Spell(bloodlust)
      */
     private TimeInCombat = (
         positionalParams: LuaArray<any>,
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         if (this.isInCombat(atTime)) {
-            const start = this.GetState(atTime).combatStartTime;
-            return TestValue(start, huge, 0, start, 1, comparator, limit);
+            const state = this.GetState(atTime);
+            const start = state.combatStartTime;
+            return TestValue(start, INFINITY, 0, start, 1);
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     private expectedCombatLength: ConditionFunction = (

--- a/src/states/combat.ts
+++ b/src/states/combat.ts
@@ -8,7 +8,6 @@ import { OvaleSpellBookClass } from "./SpellBook";
 import { LuaArray } from "@wowts/lua";
 import {
     OvaleConditionClass,
-    Compare,
     ConditionFunction,
     ReturnBoolean,
     ReturnConstant,
@@ -157,7 +156,7 @@ export class OvaleCombatClass
             const start = state.combatStartTime;
             return ReturnValueBetween(start, INFINITY, 0, start, 1);
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     private expectedCombatLength: ConditionFunction = (

--- a/src/states/combat.ts
+++ b/src/states/combat.ts
@@ -8,10 +8,10 @@ import { OvaleSpellBookClass } from "./SpellBook";
 import { LuaArray } from "@wowts/lua";
 import {
     OvaleConditionClass,
-    TestBoolean,
     TestValue,
     Compare,
     ConditionFunction,
+    ReturnBoolean,
     ReturnConstant,
 } from "../engine/condition";
 import { huge as INFINITY } from "@wowts/math";
@@ -128,16 +128,15 @@ export class OvaleCombatClass
 	     Valid values: yes, no.
 	 @return A boolean value.
 	 @usage
-	 if InCombat(no) and Stealthed(no) Spell(stealth)
+	 if not InCombat() and not Stealthed() Spell(stealth)
      */
     private InCombat = (
         positionalParams: LuaArray<any>,
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const yesno = positionalParams[1];
         const boolean = this.isInCombat(atTime);
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /** Get the number of seconds elapsed since the player entered combat.

--- a/src/states/conditions.ts
+++ b/src/states/conditions.ts
@@ -3,7 +3,6 @@ import LibRangeCheck from "@wowts/lib_range_check-2.0";
 import {
     TestValue,
     Compare,
-    TestBoolean,
     ConditionFunction,
     ReturnValue,
     OvaleConditionClass,
@@ -212,29 +211,29 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [essenceId, yesno] = [positionalParams[1], positionalParams[2]];
+        const essenceId = positionalParams[1];
         const value = this.OvaleAzeriteEssence.IsMajorEssence(essenceId);
-        return TestBoolean(value, yesno);
+        return ReturnBoolean(value);
     };
     private AzeriteEssenceIsMinor = (
         positionalParams: LuaArray<any>,
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [essenceId, yesno] = [positionalParams[1], positionalParams[2]];
+        const essenceId = positionalParams[1];
         const value = this.OvaleAzeriteEssence.IsMinorEssence(essenceId);
-        return TestBoolean(value, yesno);
+        return ReturnBoolean(value);
     };
     private AzeriteEssenceIsEnabled = (
         positionalParams: LuaArray<any>,
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [essenceId, yesno] = [positionalParams[1], positionalParams[2]];
+        const essenceId = positionalParams[1];
         const value =
             this.OvaleAzeriteEssence.IsMajorEssence(essenceId) ||
             this.OvaleAzeriteEssence.IsMinorEssence(essenceId);
-        return TestBoolean(value, yesno);
+        return ReturnBoolean(value);
     };
     private AzeriteEssenceRank = (
         positionalParams: LuaArray<any>,
@@ -502,7 +501,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const auraId = positionalParams[1]
+        const auraId = positionalParams[1];
         const [, filter, mine] = this.ParseCondition(
             positionalParams,
             namedParams
@@ -1233,9 +1232,6 @@ export class OvaleConditions {
 	 @paramsig boolean
 	 @param class The class to check.
 	     Valid values: DEATHKNIGHT, DRUID, HUNTER, MAGE, MONK, PALADIN, PRIEST, ROGUE, SHAMAN, WARLOCK, WARRIOR.
-	 @param yesno Optional. If yes, then return true if it matches. If no, then return true if it doesn't match.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -1248,7 +1244,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [className, yesno] = [positionalParams[1], positionalParams[2]];
+        const className = positionalParams[1];
         const [target] = this.ParseCondition(positionalParams, namedParams);
 
         let classToken;
@@ -1258,7 +1254,7 @@ export class OvaleConditions {
             [, classToken] = UnitClass(target);
         }
         const boolean = classToken == upper(className);
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /** Test whether the target's classification matches the given classification.
@@ -1266,9 +1262,6 @@ export class OvaleConditions {
 	 @paramsig boolean
 	 @param classification The unit classification to check.
 	     Valid values: normal, elite, worldboss.
-	 @param yesno Optional. If yes, then return true if it matches. If no, then return true if it doesn't match.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -1281,10 +1274,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [classification, yesno] = [
-            positionalParams[1],
-            positionalParams[2],
-        ];
+        const classification = positionalParams[1];
         let targetClassification;
         const [target] = this.ParseCondition(positionalParams, namedParams);
         if (UnitLevel(target) < 0) {
@@ -1314,7 +1304,7 @@ export class OvaleConditions {
             }
         }
         const boolean = targetClassification == classification;
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /**  Get the current value of a script counter.
@@ -1342,9 +1332,6 @@ export class OvaleConditions {
 	 @paramsig boolean
 	 @param name The English name of the creature family to check.
 	     Valid values: Bat, Beast, Felguard, Imp, Ravager, etc.
-	 @param yesno Optional. If yes, then return true if it matches. If no, then return true if it doesn't match.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -1791,26 +1778,22 @@ export class OvaleConditions {
     /** Test if the target exists. The target may be alive or dead.
 	 @name Exists
 	 @paramsig boolean
-	 @param yesno Optional. If yes, then return true if the target exists. If no, then return true if it doesn't exist.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
 	 @return A boolean value.
 	 @see Present
 	 @usage
-	 if pet.Exists(no) Spell(summon_imp)
+	 if not pet.Exists() Spell(summon_imp)
      */
     private Exists = (
         positionalParams: LuaArray<any>,
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const yesno = positionalParams[1];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const boolean = UnitExists(target);
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /** A condition that always returns false.
@@ -1950,28 +1933,23 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [, yesno] = [positionalParams[1], positionalParams[2]];
-        return TestBoolean(false, yesno);
+        return ReturnBoolean(false);
     };
 
     /** Test if the player has full control, i.e., isn't feared, charmed, etc.
 	 @name HasFullControl
 	 @paramsig boolean
-	 @param yesno Optional. If yes, then return true if the target exists. If no, then return true if it doesn't exist.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @return A boolean value.
 	 @usage
-	 if HasFullControl(no) Spell(barkskin)
+	 if not HasFullControl() Spell(barkskin)
      */
     private HasFullControlCondition = (
         positionalParams: LuaArray<any>,
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const yesno = positionalParams[1];
         const boolean = HasFullControl();
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /** Get the current amount of health points of the target.
@@ -2231,9 +2209,6 @@ export class OvaleConditions {
 	 @name InFlightToTarget
 	 @paramsig boolean
 	 @param id The spell ID.
-	 @param yesno Optional. If yes, then return true if the spell is in flight. If no, then return true if it isn't in flight.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @return A boolean value.
 	 @usage
 	 if target.DebuffRemaining(haunt) <3 and not InFlightToTarget(haunt)
@@ -2244,20 +2219,17 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, yesno] = [positionalParams[1], positionalParams[2]];
+        const spellId = positionalParams[1];
         const boolean =
             this.OvaleFuture.next.currentCast.spellId == spellId ||
             this.OvaleFuture.InFlight(spellId);
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /** Test if the distance from the player to the target is within the spell's range.
 	 @name InRange
 	 @paramsig boolean
 	 @param id The spell ID.
-	 @param yesno Optional. If yes, then return true if the target is in range. If no, then return true if it isn't in range.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @return A boolean value.
 	 @usage
 	 if target.IsInterruptible() and target.InRange(kick)
@@ -2268,10 +2240,10 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, yesno] = [positionalParams[1], positionalParams[2]];
+        const spellId = positionalParams[1];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const boolean = this.OvaleSpells.IsSpellInRange(spellId, target);
-        return TestBoolean(boolean || false, yesno);
+        return ReturnBoolean(boolean || false);
     };
 
     /** Test if the target's primary aggro is on the player.
@@ -2279,9 +2251,6 @@ export class OvaleConditions {
 	 this condition returns true as long as the player is highest on the threat table.
 	 @name IsAggroed
 	 @paramsig boolean
-	 @param yesno Optional. If yes, then return true if the target is aggroed. If no, then return true if it isn't aggroed.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -2294,18 +2263,14 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const yesno = positionalParams[1];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const [boolean] = UnitDetailedThreatSituation("player", target);
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean || false);
     };
 
     /**  Test if the target is dead.
 	 @name IsDead
 	 @paramsig boolean
-	 @param yesno Optional. If yes, then return true if the target is dead. If no, then return true if it isn't dead.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -2318,18 +2283,14 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const yesno = positionalParams[1];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const boolean = UnitIsDead(target);
-        return TestBoolean(boolean || false, yesno);
+        return ReturnBoolean(boolean || false);
     };
 
     /** Test if the target is enraged.
 	 @name IsEnraged
 	 @paramsig boolean
-	 @param yesno Optional. If yes, then return true if enraged. If no, then return true if not enraged.
-	     Default is yes.
-	     Valid values: yes.  "no" currently doesn't work.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -2360,9 +2321,6 @@ export class OvaleConditions {
     /**  Test if the player is feared.
 	 @name IsFeared
 	 @paramsig boolean
-	 @param yesno Optional. If yes, then return true if feared. If no, then return true if it not feared.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @return A boolean value.
 	 @usage
 	 if IsFeared() Spell(every_man_for_himself)
@@ -2372,19 +2330,15 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const yesno = positionalParams[1];
         const boolean =
             !HasFullControl() &&
             this.OvaleLossOfControl.HasLossOfControl("FEAR", atTime);
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /** Test if the target is friendly to the player.
 	 @name IsFriend
 	 @paramsig boolean
-	 @param yesno Optional. If yes, then return true if the target is friendly (able to help in combat). If no, then return true if it isn't friendly.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -2397,18 +2351,14 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const yesno = positionalParams[1];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const boolean = UnitIsFriend("player", target);
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /** Test if the player is incapacitated.
 	 @name IsIncapacitated
 	 @paramsig boolean
-	 @param yesno Optional. If yes, then return true if incapacitated. If no, then return true if it not incapacitated.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @return A boolean value.
 	 @usage
 	 if IsIncapacitated() Spell(every_man_for_himself)
@@ -2418,19 +2368,15 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const yesno = positionalParams[1];
         const boolean =
             !HasFullControl() &&
             this.OvaleLossOfControl.HasLossOfControl("CONFUSE", atTime);
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /**  Test if the target is currently casting an interruptible spell.
 	 @name IsInterruptible
 	 @paramsig boolean
-	 @param yesno Optional. If yes, then return true if the target is interruptible. If no, then return true if it isn't interruptible.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -2443,22 +2389,18 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const yesno = positionalParams[1];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         let [name, , , , , , , notInterruptible] = UnitCastingInfo(target);
         if (!name) {
             [name, , , , , , notInterruptible] = UnitChannelInfo(target);
         }
         const boolean = notInterruptible != undefined && !notInterruptible;
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /**  Test if the target is flagged for PvP activity.
 	 @name IsPVP
 	 @paramsig boolean
-	 @param yesno Optional. If yes, then return true if the target is flagged for PvP activity. If no, then return true if it isn't PvP-flagged.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -2471,17 +2413,13 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const yesno = positionalParams[1];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const boolean = UnitIsPVP(target);
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
     /** Test if the player is rooted.
 	 @name IsRooted
 	 @paramsig boolean
-	 @param yesno Optional. If yes, then return true if rooted. If no, then return true if it not rooted.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @return A boolean value.
 	 @usage
 	 if IsRooted() Item(Trinket0Slot usable=1)
@@ -2491,20 +2429,16 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const yesno = positionalParams[1];
         const boolean = this.OvaleLossOfControl.HasLossOfControl(
             "ROOT",
             atTime
         );
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /** Test if the player is stunned.
 	 @name IsStunned
 	 @paramsig boolean
-	 @param yesno Optional. If yes, then return true if stunned. If no, then return true if it not stunned.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @return A boolean value.
 	 @usage
 	 if IsStunned() Item(Trinket0Slot usable=1)
@@ -2514,11 +2448,10 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const yesno = positionalParams[1];
         const boolean =
             !HasFullControl() &&
             this.OvaleLossOfControl.HasLossOfControl("STUN_MECHANIC", atTime);
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
     /**  Get the current number of charges of the given item in the player's inventory.
 	 @name ItemCharges
@@ -2643,9 +2576,6 @@ export class OvaleConditions {
 	 @name Name
 	 @paramsig boolean
 	 @param name The localized target name.
-	 @param yesno Optional. If yes, then return true if it matches. If no, then return true if it doesn't match.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -2711,9 +2641,6 @@ export class OvaleConditions {
 	 PetPresent() is equivalent to pet.Present().
 	 @name PetPresent
 	 @paramsig boolean
-	 @param yesno Optional. If yes, then return true if the target exists. If no, then return true if it doesn't exist.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @return A boolean value.
 	 @see Present
 	 @usage
@@ -2728,14 +2655,13 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const yesno = positionalParams[1];
         const name = namedParams.name;
         const target = "pet";
         const boolean =
             UnitExists(target) &&
             !UnitIsDead(target) &&
             (name == undefined || name == UnitName(target));
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /**  Return the maximum power of the given power type on the target.
@@ -3802,9 +3728,6 @@ l    */
     /** Test if the target exists and is alive.
 	 @name Present
 	 @paramsig boolean
-	 @param yesno Optional. If yes, then return true if the target exists. If no, then return true if it doesn't exist.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3819,19 +3742,15 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const yesno = positionalParams[1];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const boolean = UnitExists(target) && !UnitIsDead(target);
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /** Test if the previous spell cast that invoked the GCD matches the given spell.
 	 @name PreviousGCDSpell
 	 @paramsig boolean
 	 @param id The spell ID.
-	 @param yesno Optional. If yes, then return true if there is a match. If no, then return true if it doesn't match.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @return A boolean value.
      */
     private PreviousGCDSpell = (
@@ -3839,7 +3758,7 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spell, yesno] = [positionalParams[1], positionalParams[2]];
+        const spell = positionalParams[1];
         const spellId = this.OvaleSpellBook.getKnownSpellId(spell);
         const count = namedParams.count as number | undefined;
         let boolean;
@@ -3852,16 +3771,13 @@ l    */
         } else {
             boolean = spellId == this.OvaleFuture.next.lastGCDSpellId;
         }
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /** Test if the previous spell cast that did not trigger the GCD matches the given spell.
 	 @name PreviousOffGCDSpell
 	 @paramsig boolean
 	 @param id The spell ID.
-	 @param yesno Optional. If yes, then return true if there is a match. If no, then return true if it doesn't match.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @return A boolean value.
      */
     private PreviousOffGCDSpell = (
@@ -3869,20 +3785,17 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spell, yesno] = [positionalParams[1], positionalParams[2]];
+        const spell = positionalParams[1];
         const spellId = this.OvaleSpellBook.getKnownSpellId(spell);
         const boolean =
             spellId == this.OvaleFuture.next.lastOffGCDSpellcast.spellId;
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /**  Test if the previous spell cast matches the given spell.
 	 @name PreviousSpell
 	 @paramsig boolean
 	 @param id The spell ID.
-	 @param yesno Optional. If yes, then return true if there is a match. If no, then return true if it doesn't match.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @return A boolean value.
      */
     private PreviousSpell = (
@@ -3890,10 +3803,10 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spell, yesno] = [positionalParams[1], positionalParams[2]];
+        const spell = positionalParams[1];
         const spellId = this.OvaleSpellBook.getKnownSpellId(spell);
         const boolean = spellId == this.OvaleFuture.next.lastGCDSpellId;
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /**  Get the result of the target's level minus the player's level. This number may be negative.
@@ -4497,7 +4410,7 @@ l    */
             duration,
         ] = this.OvaleCooldown.GetSpellCharges(spellId, atTime);
         if (charges && charges < maxCharges) {
-			const ending = start + duration;
+            const ending = start + duration;
             return TestValue(start, ending, duration, start, -1);
         }
         return Compare(0);
@@ -4585,7 +4498,7 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const usable = (namedParams.usable == 1);
+        const usable = namedParams.usable == 1;
         const [target] = this.ParseCondition(
             positionalParams,
             namedParams,
@@ -4770,10 +4683,6 @@ l    */
 	 @name SpellKnown
 	 @paramsig boolean
 	 @param id The spell ID.
-	 @param yesno Optional. If yes, then return true if the spell has been learned.
-	     If no, then return true if the player hasn't learned the spell.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @return A boolean value.
 	 @see SpellUsable
      */
@@ -4782,9 +4691,9 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, yesno] = [positionalParams[1], positionalParams[2]];
+        const spellId = positionalParams[1];
         const boolean = this.OvaleSpellBook.IsKnownSpell(spellId);
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /** Get the maximum number of charges of the spell.
@@ -4824,9 +4733,6 @@ l    */
 	 @name SpellUsable
 	 @paramsig boolean
 	 @param id The spell ID.
-	 @param yesno Optional. If yes, then return true if the spell is usable. If no, then return true if it isn't usable.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @return A boolean value.
 	 @see SpellKnown
      */
@@ -4835,7 +4741,7 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, yesno] = [positionalParams[1], positionalParams[2]];
+        const spellId = positionalParams[1];
         const [target] = this.ParseCondition(
             positionalParams,
             namedParams,
@@ -4849,16 +4755,13 @@ l    */
             targetGuid
         );
         const boolean = isUsable || noMana;
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /** Test if the player is currently stealthed.
 	 The player is stealthed if rogue Stealth, druid Prowl, or a similar ability is active.
 	 @name Stealthed
 	 @paramsig boolean
-	 @param yesno Optional. If yes, then return true if stealthed. If no, then return true if it not stealthed.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @return A boolean value.
 	 @usage
 	 if Stealthed() or BuffPresent(shadow_dance)
@@ -4869,7 +4772,6 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const yesno = positionalParams[1];
         const boolean =
             this.OvaleAura.GetAura(
                 "player",
@@ -4877,7 +4779,7 @@ l    */
                 atTime,
                 "HELPFUL"
             ) !== undefined || IsStealthed();
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /** Get the time elapsed in seconds since the player's previous melee swing (white attack).
@@ -4926,9 +4828,6 @@ l    */
 	 @name Talent
 	 @paramsig boolean
 	 @param id The talent ID.
-	 @param yesno Optional. If yes, then return true if the talent is active. If no, then return true if it isn't active.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @return A boolean value.
 	 @usage
 	 if Talent(blood_tap_talent) Spell(blood_tap)
@@ -4938,9 +4837,9 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [talentId, yesno] = [positionalParams[1], positionalParams[2]];
+        const talentId = positionalParams[1];
         const boolean = this.OvaleSpellBook.GetTalentPoints(talentId) > 0;
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /** Get the number of points spent in a talent (0 or 1)
@@ -4965,9 +4864,6 @@ l    */
     /** Test if the player is the in-game target of the target.
 	 @name TargetIsPlayer
 	 @paramsig boolean
-	 @param yesno Optional. If yes, then return true if it matches. If no, then return true if it doesn't match.
-	     Default is yes.
-	     Valid values: yes, no.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -4980,10 +4876,9 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const yesno = positionalParams[1];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const boolean = UnitIsUnit("player", `${target}target`);
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /** Get the amount of threat on the current target relative to the its primary aggro target, scaled to between 0 (zero) and 100.
@@ -5213,11 +5108,7 @@ l    */
 
     /** Get the number of seconds before the player reaches the given power level.
      */
-    private TimeToPower(
-        powerType: PowerType,
-        level: number,
-        atTime: number
-    ) {
+    private TimeToPower(powerType: PowerType, level: number, atTime: number) {
         level = level || 0;
         const seconds = this.OvalePower.getTimeToPowerAt(
             this.OvalePower.next,
@@ -5539,7 +5430,7 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, yesno] = [positionalParams[1], positionalParams[2]];
+        const spellId = positionalParams[1];
         const spellName = this.OvaleSpellBook.GetSpellName(spellId);
         const numTrackingTypes = GetNumTrackingTypes();
         let boolean = false;
@@ -5550,7 +5441,7 @@ l    */
                 break;
             }
         }
-        return TestBoolean(boolean, yesno);
+        return ReturnBoolean(boolean);
     };
 
     /** The travel time of a spell to the target in seconds.
@@ -5647,7 +5538,7 @@ l    */
         for (const [, v] of ipairs(positionalParams)) {
             charging = charging || this.OvaleSigil.IsSigilCharging(v, atTime);
         }
-        return TestBoolean(charging, "yes");
+        return ReturnBoolean(charging);
     };
 
     /** Test with DBM or BigWigs (if available) whether a boss is currently engaged
@@ -5663,7 +5554,7 @@ l    */
         atTime: number
     ) => {
         const bossEngaged = this.OvaleBossMod.IsBossEngaged(atTime);
-        return TestBoolean(bossEngaged, "yes");
+        return ReturnBoolean(bossEngaged);
     };
 
     /** Check for the target's race
@@ -5686,7 +5577,7 @@ l    */
         for (const [, v] of ipairs(positionalParams)) {
             isRace = isRace || v == targetRaceId;
         }
-        return TestBoolean(isRace, "yes");
+        return ReturnBoolean(isRace);
     };
 
     /**  Check if the unit is in a party
@@ -5703,8 +5594,8 @@ l    */
         atTime: number
     ) => {
         const target = (namedParams.target as string | undefined) || "player";
-        const isTrue = UnitInParty(target);
-        return TestBoolean(isTrue, "yes");
+        const boolean = UnitInParty(target);
+        return ReturnBoolean(boolean);
     };
 
     /**  Check if the unit is in raid
@@ -5722,7 +5613,7 @@ l    */
     ) => {
         const target = (namedParams.target as string | undefined) || "player";
         const raidIndex = UnitInRaid(target);
-        return TestBoolean(raidIndex != undefined, "yes");
+        return ReturnBoolean(raidIndex != undefined);
     };
 
     /** Check the amount of Soul Fragments for Vengeance DH
@@ -5741,9 +5632,6 @@ l    */
     /** Test if a specific dispel type is present.
 	 @name HasDebuffType
 	 @paramsig boolean
-	 @param yesno Optional. If yes, then return true if enraged. If no, then return true if not enraged.
-	     Default is yes.
-	     Valid values: yes.  "no" currently doesn't work.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.

--- a/src/states/conditions.ts
+++ b/src/states/conditions.ts
@@ -5,7 +5,6 @@ import {
     Compare,
     TestBoolean,
     ConditionFunction,
-    isComparator,
     ReturnValue,
     OvaleConditionClass,
     ReturnConstant,
@@ -191,8 +190,6 @@ export class OvaleConditions {
 	@param name The name of the armor set.
 	    Valid names: T11, T12, T13, T14, T15.
 	    Valid names for hybrid classes: append _caster, _heal, _melee, _tank.
-	@param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	@param number Optional. The number to compare against.
 	@return The number of pieces of the named set that are equipped by the player.
 	@return A boolean value for the result of the comparison.
 	@usage
@@ -205,14 +202,9 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
         const value = 0;
         OneTimeMessage("Warning: 'ArmorSetBonus()' is depreciated.  Returns 0");
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     private AzeriteEssenceIsMajor = (
@@ -249,21 +241,15 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [essenceId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const essenceId = positionalParams[1];
         const value = this.OvaleAzeriteEssence.EssenceRank(essenceId);
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /** Get the base duration of the aura in seconds if it is applied at the current time.
 	@name BaseDuration
 	@paramsig number or boolean
 	@param id The aura spell ID.
-	@param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	@param number Optional. The number to compare against.
 	@return The base duration in seconds.
 	@return A boolean value for the result of the comparison.
 	@see BuffDuration
@@ -276,11 +262,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [auraId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const auraId = positionalParams[1];
         let value = 0;
         if (this.OvaleData.buffSpellList[auraId]) {
             const spellList = this.OvaleData.buffSpellList[auraId];
@@ -299,15 +281,13 @@ export class OvaleConditions {
                 this.OvalePaperDoll.next
             );
         }
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /** Get the value of a buff as a number.  Not all buffs return an amount.
 	 @name BuffAmount
 	 @paramsig number
 	 @param id The spell ID of the aura or the name of a spell list.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -321,18 +301,13 @@ export class OvaleConditions {
 	 @see DebuffAmount
 	 @see TickValue
 	 @usage
-	 if DebuffAmount(stagger) >10000 Spell(purifying_brew)
-	 if DebuffAmount(stagger more 10000) Spell(purifying_brew) */
+	 if DebuffAmount(stagger) >10000 Spell(purifying_brew) */
     private BuffAmount = (
         positionalParams: LuaArray<any>,
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [auraId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const auraId = positionalParams[1];
         const [target, filter, mine] = this.ParseCondition(
             positionalParams,
             namedParams
@@ -356,17 +331,15 @@ export class OvaleConditions {
         if (aura && this.OvaleAura.IsActiveAura(aura, atTime)) {
             const [gain, start, ending] = [aura.gain, aura.start, aura.ending];
             const value = aura[statName] || 0;
-            return TestValue(gain, ending, value, start, 0, comparator, limit);
+            return TestValue(gain, ending, value, start, 0);
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     /** Get the player's combo points for the given aura at the time the aura was applied on the target.
 	 @name BuffComboPoints
 	 @paramsig number or boolean
 	 @param id The aura spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -380,11 +353,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [auraId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const auraId = positionalParams[1];
         const [target, filter, mine] = this.ParseCondition(
             positionalParams,
             namedParams
@@ -399,17 +368,15 @@ export class OvaleConditions {
         if (aura && this.OvaleAura.IsActiveAura(aura, atTime)) {
             const [gain, start, ending] = [aura.gain, aura.start, aura.ending];
             const value = (aura && aura.combopoints) || 0;
-            return TestValue(gain, ending, value, start, 0, comparator, limit);
+            return TestValue(gain, ending, value, start, 0);
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     /** Get the number of seconds before a buff can be gained again.
 	 @name BuffCooldown
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @return A boolean value for the result of the comparison.
 	 @see DebuffCooldown
@@ -448,8 +415,6 @@ export class OvaleConditions {
 	 @name BuffCount
 	 @paramsig number or boolean
 	 @param id the spell list ID	
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of buffs
 	 @return A boolean value for the result of the comparison
 	 */
@@ -458,11 +423,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [auraId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const auraId = positionalParams[1];
         const [target, filter, mine] = this.ParseCondition(
             positionalParams,
             namedParams
@@ -481,15 +442,13 @@ export class OvaleConditions {
                 count = count + 1;
             }
         }
-        return Compare(count, comparator, limit);
+        return Compare(count);
     };
 
     /** Get the duration in seconds of the cooldown before a buff can be gained again.
 	 @name BuffCooldownDuration
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @return A boolean value for the result of the comparison.
 	 @see DebuffCooldown
@@ -502,11 +461,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [auraId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const auraId = positionalParams[1];
         let minCooldown = INFINITY;
         if (this.OvaleData.buffSpellList[auraId]) {
             for (const [id] of pairs(this.OvaleData.buffSpellList[auraId])) {
@@ -519,15 +474,13 @@ export class OvaleConditions {
         } else {
             minCooldown = 0;
         }
-        return Compare(minCooldown, comparator, limit);
+        return Compare(minCooldown);
     };
 
     /** /** Get the total count of the given aura across all targets.
 	 @name BuffCountOnAny
 	 @paramsig number or boolean
 	 @param id The spell ID of the aura or the name of a spell list.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param stacks Optional. The minimum number of stacks of the aura required.
 	     Defaults to stacks=1.
 	     Valid values: any number greater than zero.
@@ -549,11 +502,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [auraId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const auraId = positionalParams[1]
         const [, filter, mine] = this.ParseCondition(
             positionalParams,
             namedParams
@@ -581,17 +530,9 @@ export class OvaleConditions {
             const origin = startChangeCount;
             const rate = -1 / (endingChangeCount - startChangeCount);
             const [start, ending] = [startFirst, endingLast];
-            return TestValue(
-                start,
-                ending,
-                count,
-                origin,
-                rate,
-                comparator,
-                limit
-            );
+            return TestValue(start, ending, count, origin, rate);
         }
-        return Compare(count, comparator, limit);
+        return Compare(count);
     };
 
     /** Get the current direction of an aura's stack count.
@@ -600,8 +541,6 @@ export class OvaleConditions {
 	 @name BuffDirection
 	 @paramsig number or boolean
 	 @param id The spell ID of the aura or the name of a spell list.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param any Optional. Sets by whom the aura was applied. If the aura can be applied by anyone, then set any=1.
 	     Defaults to any=0.
 	     Valid values: 0, 1.
@@ -617,11 +556,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [auraId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const auraId = positionalParams[1];
         const [target, filter, mine] = this.ParseCondition(
             positionalParams,
             namedParams
@@ -640,25 +575,15 @@ export class OvaleConditions {
                 aura.ending,
                 aura.direction,
             ];
-            return TestValue(
-                gain,
-                INFINITY,
-                direction,
-                gain,
-                0,
-                comparator,
-                limit
-            );
+            return TestValue(gain, INFINITY, direction, gain, 0);
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     /** Get the total duration of the aura from when it was first applied to when it ended.
 	 @name BuffDuration
 	 @paramsig number or boolean
 	 @param id The aura spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -671,11 +596,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [auraId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const auraId = positionalParams[1];
         const [target, filter, mine] = this.ParseCondition(
             positionalParams,
             namedParams
@@ -690,9 +611,9 @@ export class OvaleConditions {
         if (aura && this.OvaleAura.IsActiveAura(aura, atTime)) {
             const [gain, start, ending] = [aura.gain, aura.start, aura.ending];
             const value = ending - start;
-            return TestValue(gain, ending, value, start, 0, comparator, limit);
+            return TestValue(gain, ending, value, start, 0);
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     /** Test if an aura is expired, or will expire after a given number of seconds.
@@ -808,8 +729,6 @@ export class OvaleConditions {
     /** Get the time elapsed since the aura was last gained on the target.
 	 @paramsig number or boolean
 	 @param id The spell ID of the aura or the name of a spell list.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param any Optional. Sets by whom the aura was applied. If the aura can be applied by anyone, then set any=1.
 	     Defaults to any=0.
 	     Valid values: 0, 1.
@@ -824,11 +743,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [auraId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const auraId = positionalParams[1];
         const [target, filter, mine] = this.ParseCondition(
             positionalParams,
             namedParams
@@ -842,9 +757,9 @@ export class OvaleConditions {
         );
         if (aura) {
             const gain = aura.gain || 0;
-            return TestValue(gain, INFINITY, 0, gain, 1, comparator, limit);
+            return TestValue(gain, INFINITY, 0, gain, 1);
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     private BuffImproved = (
@@ -852,14 +767,9 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
         let [, ,] = this.ParseCondition(positionalParams, namedParams);
         // TODO Not implemented
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     /** Get the player's persistent multiplier for the given aura at the time the aura was applied on the target.
@@ -867,8 +777,6 @@ export class OvaleConditions {
 	 @name BuffPersistentMultiplier
 	 @paramsig number or boolean
 	 @param id The aura spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -883,11 +791,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [auraId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const auraId = positionalParams[1];
         const [target, filter, mine] = this.ParseCondition(
             positionalParams,
             namedParams
@@ -902,17 +806,15 @@ export class OvaleConditions {
         if (aura && this.OvaleAura.IsActiveAura(aura, atTime)) {
             const [gain, start, ending] = [aura.gain, aura.start, aura.ending];
             const value = aura.damageMultiplier || 1;
-            return TestValue(gain, ending, value, start, 0, comparator, limit);
+            return TestValue(gain, ending, value, start, 0);
         }
-        return Compare(1, comparator, limit);
+        return Compare(1);
     };
 
     /** Get the remaining time in seconds on an aura.
 	 @name BuffRemaining
 	 @paramsig number or boolean
 	 @param id The spell ID of the aura or the name of a spell list.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param any Optional. Sets by whom the aura was applied. If the aura can be applied by anyone, then set any=1.
 	     Defaults to any=0.
 	     Valid values: 0, 1.
@@ -931,11 +833,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [auraId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const auraId = positionalParams[1];
         const [target, filter, mine] = this.ParseCondition(
             positionalParams,
             namedParams
@@ -949,17 +847,15 @@ export class OvaleConditions {
         );
         if (aura && aura.ending >= atTime) {
             const [gain, , ending] = [aura.gain, aura.start, aura.ending];
-            return TestValue(gain, INFINITY, 0, ending, -1, comparator, limit);
+            return TestValue(gain, INFINITY, 0, ending, -1);
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     /** Get the remaining time in seconds before the aura expires across all targets.
 	 @name BuffRemainingOnAny
 	 @paramsig number or boolean
 	 @param id The spell ID of the aura or the name of a spell list.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param stacks Optional. The minimum number of stacks of the aura required.
 	     Defaults to stacks=1.
 	     Valid values: any number greater than zero.
@@ -978,11 +874,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [auraId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const auraId = positionalParams[1];
         const [, filter, mine] = this.ParseCondition(
             positionalParams,
             namedParams
@@ -1000,17 +892,15 @@ export class OvaleConditions {
         );
         if (count > 0) {
             const [start, ending] = [startFirst, endingLast];
-            return TestValue(start, INFINITY, 0, ending, -1, comparator, limit);
+            return TestValue(start, INFINITY, 0, ending, -1);
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     /** Get the number of stacks of an aura on the target.
 	 @name BuffStacks
 	 @paramsig number or boolean
 	 @param id The spell ID of the aura or the name of a spell list.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param any Optional. Sets by whom the aura was applied. If the aura can be applied by anyone, then set any=1.
 	     Defaults to any=0.
 	     Valid values: 0, 1.
@@ -1031,11 +921,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [auraId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const auraId = positionalParams[1];
         const [target, filter, mine] = this.ParseCondition(
             positionalParams,
             namedParams
@@ -1050,9 +936,9 @@ export class OvaleConditions {
         if (aura && this.OvaleAura.IsActiveAura(aura, atTime)) {
             const [gain, start, ending] = [aura.gain, aura.start, aura.ending];
             const value = aura.stacks || 0;
-            return TestValue(gain, ending, value, start, 0, comparator, limit);
+            return TestValue(gain, ending, value, start, 0);
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     private maxStacks = (
@@ -1060,22 +946,16 @@ export class OvaleConditions {
         namedParameters: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [auraId, comparator, limit] = [
-            positionalParams[1] as number,
-            positionalParams[2] as string,
-            positionalParams[3] as number,
-        ];
+        const auraId = positionalParams[1] as number;
         const spellInfo = this.OvaleData.GetSpellInfo(auraId);
         const maxStacks = (spellInfo && spellInfo.max_stacks) || 0;
-        return Compare(maxStacks, comparator, limit);
+        return Compare(maxStacks);
     };
 
     /** Get the total number of stacks of the given aura across all targets.
 	 @name BuffStacksOnAny
 	 @paramsig number or boolean
 	 @param id The spell ID of the aura or the name of a spell list.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param any Optional. Sets by whom the aura was applied. If the aura can be applied by anyone, then set any=1.
 	     Defaults to any=0.
 	     Valid values: 0, 1.
@@ -1091,11 +971,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [auraId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const auraId = positionalParams[1];
         const [, filter, mine] = this.ParseCondition(
             positionalParams,
             namedParams
@@ -1119,17 +995,9 @@ export class OvaleConditions {
         );
         if (count > 0) {
             const [start, ending] = [startFirst, endingChangeCount];
-            return TestValue(
-                start,
-                ending,
-                stacks,
-                start,
-                0,
-                comparator,
-                limit
-            );
+            return TestValue(start, ending, stacks, start, 0);
         }
-        return Compare(count, comparator, limit);
+        return Compare(count);
     };
 
     /** Test if there is a stealable buff on the target.
@@ -1180,8 +1048,6 @@ export class OvaleConditions {
 	 @name CastTime
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @return A boolean value for the result of the comparison.
 	 @see ExecuteTime
@@ -1194,21 +1060,15 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const spellId = positionalParams[1];
         const castTime = this.OvaleSpellBook.GetCastTime(spellId) || 0;
-        return Compare(castTime, comparator, limit);
+        return Compare(castTime);
     };
 
     /** Get the cast time in seconds of the spell for the player or the GCD for the player, whichever is greater.
 	 @name ExecuteTime
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @return A boolean value for the result of the comparison.
 	 @see CastTime
@@ -1221,15 +1081,11 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const spellId = positionalParams[1];
         const castTime = this.OvaleSpellBook.GetCastTime(spellId) || 0;
         const gcd = this.OvaleFuture.GetGCD(atTime);
         const t = (castTime > gcd && castTime) || gcd;
-        return Compare(t, comparator, limit);
+        return Compare(t);
     };
 
     /** Test if the target is casting the given spell.
@@ -1465,8 +1321,6 @@ export class OvaleConditions {
 	 @name Counter
 	 @paramsig number or boolean
 	 @param id The name of the counter. It should match one that's defined by inccounter=xxx in SpellInfo(...).
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current value the counter.
 	 @return A boolean value for the result of the comparison.
      */
@@ -1475,13 +1329,9 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [counter, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const counter = positionalParams[1];
         const value = this.OvaleFuture.GetCounter(counter, atTime);
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /** Test whether the target's creature family matches the given name.
@@ -1551,8 +1401,6 @@ export class OvaleConditions {
 	 @name CritDamage
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -1565,11 +1413,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const spellId = positionalParams[1];
         const [target] = this.ParseCondition(
             positionalParams,
             namedParams,
@@ -1604,7 +1448,7 @@ export class OvaleConditions {
             }
         }
         value = critMultiplier * value;
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /**  Get the current estimated damage of a spell on the target.
@@ -1612,8 +1456,6 @@ export class OvaleConditions {
 	 @name Damage
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -1629,11 +1471,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const spellId = positionalParams[1];
         const [target] = this.ParseCondition(
             positionalParams,
             namedParams,
@@ -1644,15 +1482,13 @@ export class OvaleConditions {
         if (si && si.physical == 1) {
             value = value * (1 - BossArmorDamageReduction(target));
         }
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /**  Get the total damage taken by the player in the previous time interval.
 	 @name DamageTaken
 	 @paramsig number or boolean
 	 @param interval The number of seconds before now.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The amount of damage taken in the previous interval.
 	 @return A boolean value for the result of the comparison.
 	 @see IncomingDamage
@@ -1664,25 +1500,19 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [interval, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const interval = positionalParams[1];
         let value = 0;
         if (interval > 0) {
             const [total] = this.OvaleDamageTaken.GetRecentDamage(interval);
             value = total;
         }
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /**  Get the magic damage taken by the player in the previous time interval.
 	 @name MagicDamageTaken
 	 @paramsig number or boolean
 	 @param interval The number of seconds before now.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The amount of magic damage taken in the previous interval.
 	 @return A boolean value for the result of the comparison.
 	 @see IncomingMagicDamage
@@ -1694,11 +1524,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [interval, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const interval = positionalParams[1];
         let value = 0;
         if (interval > 0) {
             const [, totalMagic] = this.OvaleDamageTaken.GetRecentDamage(
@@ -1706,15 +1532,13 @@ export class OvaleConditions {
             );
             value = totalMagic;
         }
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /**  Get the physical damage taken by the player in the previous time interval.
 	 @name PhysicalDamageTaken
 	 @paramsig number or boolean
 	 @param interval The number of seconds before now.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The amount of physical damage taken in the previous interval.
 	 @return A boolean value for the result of the comparison.
 	 @see IncomingPhysicalDamage
@@ -1726,11 +1550,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [interval, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const interval = positionalParams[1];
         let value = 0;
         if (interval > 0) {
             const [total, totalMagic] = this.OvaleDamageTaken.GetRecentDamage(
@@ -1738,7 +1558,7 @@ export class OvaleConditions {
             );
             value = total - totalMagic;
         }
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     GetDiseases(
@@ -1765,8 +1585,6 @@ export class OvaleConditions {
     /** Get the remaining time in seconds before any diseases applied by the death knight will expire.
 	 @name DiseasesRemaining
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -1778,11 +1596,6 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
         const [target, ,] = this.ParseCondition(positionalParams, namedParams);
         const [bpAura, ffAura] = this.GetDiseases(target, atTime);
         let aura;
@@ -1796,9 +1609,9 @@ export class OvaleConditions {
         }
         if (aura) {
             const [gain, , ending] = [aura.gain, aura.start, aura.ending];
-            return TestValue(gain, INFINITY, 0, ending, -1, comparator, limit);
+            return TestValue(gain, INFINITY, 0, ending, -1);
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     /**  Test if all diseases applied by the death knight are present on the target.
@@ -1866,8 +1679,6 @@ export class OvaleConditions {
 	 You should not test for equality.
 	 @name Distance
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -1882,18 +1693,15 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const value = (LibRangeCheck && LibRangeCheck.GetRange(target)) || 0;
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /**  Get the number of hostile enemies on the battlefield.
 	 The minimum value returned is 1.
 	 @name Enemies
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param tagged Optional. By default, all enemies are counted. To count only enemies directly tagged by the player, set tagged=1.
 	     Defaults to tagged=0.
 	     Valid values: 0, 1.
@@ -1908,7 +1716,6 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         let value = this.OvaleEnemies.next.enemies;
         if (!value) {
             let useTagged = this.ovaleOptions.db.profile.apparence
@@ -1925,14 +1732,12 @@ export class OvaleConditions {
         if (value < 1) {
             value = 1;
         }
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /** Get the amount of regenerated energy per second for feral druids, non-mistweaver monks, and rogues.
 	 @name EnergyRegenRate
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current rate of energy regeneration.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -1943,20 +1748,17 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const value = this.OvalePower.getPowerRateAt(
             this.OvalePower.next,
             "energy",
             atTime
         );
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /** Get the remaining time in seconds the target is Enraged.
 	 @name EnrageRemaining
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -1971,7 +1773,6 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const aura = this.OvaleAura.GetAura(
             target,
@@ -1982,9 +1783,9 @@ export class OvaleConditions {
         );
         if (aura && aura.ending >= atTime) {
             const [gain, , ending] = [aura.gain, aura.start, aura.ending];
-            return TestValue(gain, INFINITY, 0, ending, -1, comparator, limit);
+            return TestValue(gain, INFINITY, 0, ending, -1);
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     /** Test if the target exists. The target may be alive or dead.
@@ -2028,8 +1829,6 @@ export class OvaleConditions {
     /**  Get the amount of regenerated focus per second for hunters.
 	 @name FocusRegenRate
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current rate of focus regeneration.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -2041,21 +1840,18 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const value = this.OvalePower.getPowerRateAt(
             this.OvalePower.next,
             "focus",
             atTime
         );
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /** Get the amount of focus that would be regenerated during the cast time of the given spell for hunters.
 	 @name FocusCastingRegen
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The amount of focus.
 	 @return A boolean value for the result of the comparison.
      */
@@ -2064,11 +1860,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const spellId = positionalParams[1];
         const regenRate = this.OvalePower.getPowerRateAt(
             this.OvalePower.next,
             "focus",
@@ -2095,14 +1887,12 @@ export class OvaleConditions {
             }
             power = power + regenRate * 1.5 * seconds;
         }
-        return Compare(power, comparator, limit);
+        return Compare(power);
     };
 
     /** Get the player's global cooldown in seconds.
 	 @name GCD
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -2114,16 +1904,13 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const value = this.OvaleFuture.GetGCD(atTime);
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /** Get the number of seconds before the player's global cooldown expires.
 	 @name GCDRemaining
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target of the previous spell. The target may also be given as a prefix to the condition.
 	     Defaults to target=target.
 	     Valid values: player, target, focus, pet.
@@ -2137,7 +1924,6 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const [target] = this.ParseCondition(
             positionalParams,
             namedParams,
@@ -2153,18 +1939,10 @@ export class OvaleConditions {
             const start = (spellcast && spellcast.start) || 0;
             const ending = start + duration;
             if (atTime < ending) {
-                return TestValue(
-                    start,
-                    INFINITY,
-                    0,
-                    ending,
-                    -1,
-                    comparator,
-                    limit
-                );
+                return TestValue(start, INFINITY, 0, ending, -1);
             }
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     private Glyph = (
@@ -2199,8 +1977,6 @@ export class OvaleConditions {
     /** Get the current amount of health points of the target.
 	 @name Health
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -2216,7 +1992,6 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const health = this.OvaleHealth.UnitHealth(target) || 0;
         if (health > 0) {
@@ -2228,24 +2003,14 @@ export class OvaleConditions {
                 (-1 * health) / timeToDie,
             ];
             const [start, ending] = [now, INFINITY];
-            return TestValue(
-                start,
-                ending,
-                value,
-                origin,
-                rate,
-                comparator,
-                limit
-            );
+            return TestValue(start, ending, value, origin, rate);
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     /** Get the current amount of health points of the target including absorbs.
 	 @name EffectiveHealth
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -2261,7 +2026,6 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const health =
             this.OvaleHealth.UnitHealth(target) +
@@ -2272,14 +2036,12 @@ export class OvaleConditions {
         const timeToDie = this.OvaleHealth.UnitTimeToDie(target);
         const [value, origin, rate] = [health, now, (-1 * health) / timeToDie];
         const [start, ending] = [now, INFINITY];
-        return TestValue(start, ending, value, origin, rate, comparator, limit);
+        return TestValue(start, ending, value, origin, rate);
     };
 
     /** Get the number of health points away from full health of the target.
 	 @name HealthMissing
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -2295,7 +2057,6 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const health = this.OvaleHealth.UnitHealth(target) || 0;
         const maxHealth = this.OvaleHealth.UnitHealthMax(target) || 1;
@@ -2305,24 +2066,14 @@ export class OvaleConditions {
             const timeToDie = this.OvaleHealth.UnitTimeToDie(target);
             const [value, origin, rate] = [missing, now, health / timeToDie];
             const [start, ending] = [now, INFINITY];
-            return TestValue(
-                start,
-                ending,
-                value,
-                origin,
-                rate,
-                comparator,
-                limit
-            );
+            return TestValue(start, ending, value, origin, rate);
         }
-        return Compare(maxHealth, comparator, limit);
+        return Compare(maxHealth);
     };
 
     /** Get the current percent level of health of the target.
 	 @name HealthPercent
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -2338,7 +2089,6 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const health = this.OvaleHealth.UnitHealth(target) || 0;
         if (health > 0) {
@@ -2352,24 +2102,14 @@ export class OvaleConditions {
                 (-1 * healthPercent) / timeToDie,
             ];
             const [start, ending] = [now, INFINITY];
-            return TestValue(
-                start,
-                ending,
-                value,
-                origin,
-                rate,
-                comparator,
-                limit
-            );
+            return TestValue(start, ending, value, origin, rate);
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     /** Get the current effective percent level of health of the target (including absorbs).
 	 @name EffectiveHealthPercent
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -2384,7 +2124,6 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const health =
             this.OvaleHealth.UnitHealth(target) +
@@ -2401,14 +2140,12 @@ export class OvaleConditions {
             (-1 * healthPercent) / timeToDie,
         ];
         const [start, ending] = [now, INFINITY];
-        return TestValue(start, ending, value, origin, rate, comparator, limit);
+        return TestValue(start, ending, value, origin, rate);
     };
 
     /** Get the amount of health points of the target when it is at full health.
 	 @name MaxHealth
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -2423,17 +2160,14 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const value = this.OvaleHealth.UnitHealthMax(target);
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /**  Get the estimated number of seconds remaining before the target is dead.
 	 @name TimeToDie
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -2448,29 +2182,18 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const now = this.baseState.currentTime;
         const timeToDie = this.OvaleHealth.UnitTimeToDie(target);
         const [value, origin, rate] = [timeToDie, now, -1];
         const [start] = [now, now + timeToDie];
-        return TestValue(
-            start,
-            INFINITY,
-            value,
-            origin,
-            rate,
-            comparator,
-            limit
-        );
+        return TestValue(start, INFINITY, value, origin, rate);
     };
 
     /** Get the estimated number of seconds remaining before the target reaches the given percent of max health.
 	 @name TimeToHealthPercent
 	 @paramsig number or boolean
 	 @param percent The percent of maximum health of the target.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -2485,11 +2208,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [percent, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const percent = positionalParams[1];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const health = this.OvaleHealth.UnitHealth(target) || 0;
         if (health > 0) {
@@ -2502,18 +2221,10 @@ export class OvaleConditions {
                     (timeToDie * (healthPercent - percent)) / healthPercent;
                 const [value, origin, rate] = [t, now, -1];
                 const [start, ending] = [now, now + t];
-                return TestValue(
-                    start,
-                    ending,
-                    value,
-                    origin,
-                    rate,
-                    comparator,
-                    limit
-                );
+                return TestValue(start, ending, value, origin, rate);
             }
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     /** Test if the given spell is in flight for spells that have a flight time after cast, e.g., Lava Burst.
@@ -2812,8 +2523,6 @@ export class OvaleConditions {
     /**  Get the current number of charges of the given item in the player's inventory.
 	 @name ItemCharges
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of charges.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -2827,21 +2536,15 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [itemId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const itemId = positionalParams[1];
         const value = GetItemCount(itemId, false, true);
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /** Get the current number of the given item in the player's inventory.
 	 Items with more than one charge count as one item.
 	 @name ItemCount
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The count of the item.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -2853,13 +2556,9 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [itemId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const itemId = positionalParams[1];
         const value = GetItemCount(itemId);
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /** Get the damage done by the most recent damage event for the given spell.
@@ -2867,8 +2566,6 @@ export class OvaleConditions {
 	 @name LastDamage
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The damage done.
 	 @return A boolean value for the result of the comparison.
 	 @see Damage, LastEstimatedDamage
@@ -2881,14 +2578,10 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ): ConditionResult => {
-        const [spellId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const spellId = positionalParams[1];
         const value = this.OvaleSpellDamage.Get(spellId);
         if (value) {
-            return Compare(value, comparator, limit);
+            return Compare(value);
         }
         return [];
     };
@@ -2896,8 +2589,6 @@ export class OvaleConditions {
     /**  Get the level of the target.
 	 @name Level
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -2912,7 +2603,6 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         let value;
         if (target == "player") {
@@ -2920,7 +2610,7 @@ export class OvaleConditions {
         } else {
             value = UnitLevel(target);
         }
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
     /** Test if a list is currently set to the given value.
 	 @name List
@@ -2968,8 +2658,6 @@ export class OvaleConditions {
     /** Test if the game is on a PTR server
 	 @name PTR
 	 @paramsig number
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return 1 if it is a PTR realm, or 0 if it is a live realm.
 	 @usage
 	 if PTR() > 0 Spell(wacky_new_spell)
@@ -2979,10 +2667,9 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const [version, , , uiVersion] = GetBuildInfo();
-        const value = ((version > "8.2.5" || uiVersion > 80205) && 1) || 0;
-        return Compare(value, comparator, limit);
+        const value = ((version > "9.0.2" || uiVersion > 90002) && 1) || 0;
+        return Compare(value);
     };
 
     /** Get the persistent multiplier to the given aura if applied.
@@ -2990,8 +2677,6 @@ export class OvaleConditions {
 	 @name PersistentMultiplier
 	 @paramsig number or boolean
 	 @param id The aura ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=target.
 	     Valid values: player, target, focus, pet.
@@ -3006,11 +2691,7 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const spellId = positionalParams[1];
         const [target] = this.ParseCondition(
             positionalParams,
             namedParams,
@@ -3023,7 +2704,7 @@ export class OvaleConditions {
             targetGuid,
             atTime
         );
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /** Test if the pet exists and is alive.
@@ -3065,10 +2746,6 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) {
-        const [comparator, limit] = [
-            <string>positionalParams[1],
-            <number>positionalParams[2],
-        ];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         let value;
         if (target == "player") {
@@ -3080,7 +2757,7 @@ export class OvaleConditions {
                     UnitPowerMax(target, powerInfo.id, powerInfo.segments)) ||
                 0;
         }
-        return Compare(value, comparator, limit);
+        return Compare(value);
     }
     /** Return the amount of power of the given power type on the target.
      */
@@ -3090,10 +2767,6 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) {
-        const [comparator, limit] = [
-            <string>positionalParams[1],
-            <number>positionalParams[2],
-        ];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         if (target == "player") {
             const [value, origin, rate] = [
@@ -3106,19 +2779,11 @@ export class OvaleConditions {
                 ),
             ];
             const [start, ending] = [atTime, INFINITY];
-            return TestValue(
-                start,
-                ending,
-                value,
-                origin,
-                rate,
-                comparator,
-                limit
-            );
+            return TestValue(start, ending, value, origin, rate);
         } else {
             const powerInfo = this.OvalePower.POWER_INFO[powerType];
             const value = (powerInfo && UnitPower(target, powerInfo.id)) || 0;
-            return Compare(value, comparator, limit);
+            return Compare(value);
         }
     }
     /**Return the current deficit of power from max power on the target.
@@ -3129,10 +2794,6 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) {
-        const [comparator, limit] = [
-            <string>positionalParams[1],
-            <number>positionalParams[2],
-        ];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         if (target == "player") {
             const powerMax = this.OvalePower.current.maxPower[powerType] || 0;
@@ -3149,15 +2810,7 @@ export class OvaleConditions {
                         ),
                 ];
                 const [start, ending] = [atTime, INFINITY];
-                return TestValue(
-                    start,
-                    ending,
-                    value,
-                    origin,
-                    rate,
-                    comparator,
-                    limit
-                );
+                return TestValue(start, ending, value, origin, rate);
             }
         } else {
             const powerInfo = this.OvalePower.POWER_INFO[powerType];
@@ -3169,10 +2822,10 @@ export class OvaleConditions {
                 const power =
                     (powerInfo && UnitPower(target, powerInfo.id)) || 0;
                 const value = powerMax - power;
-                return Compare(value, comparator, limit);
+                return Compare(value);
             }
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     }
 
     /**Return the current percent level of power (between 0 and 100) on the target.
@@ -3183,10 +2836,6 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) {
-        const [comparator, limit] = [
-            <string>positionalParams[1],
-            <number>positionalParams[2],
-        ];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         if (target == "player") {
             const powerMax = this.OvalePower.current.maxPower[powerType] || 0;
@@ -3205,15 +2854,7 @@ export class OvaleConditions {
                     rate = 0;
                 }
                 const [start, ending] = [atTime, INFINITY];
-                return TestValue(
-                    start,
-                    ending,
-                    value,
-                    origin,
-                    rate,
-                    comparator,
-                    limit
-                );
+                return TestValue(start, ending, value, origin, rate);
             }
         } else {
             const powerInfo = this.OvalePower.POWER_INFO[powerType];
@@ -3227,18 +2868,16 @@ export class OvaleConditions {
                     (powerInfo &&
                         UnitPower(target, powerInfo.id) * conversion) ||
                     0;
-                return Compare(value, comparator, limit);
+                return Compare(value);
             }
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     }
 
     /**
      Get the current amount of alternate power displayed on the alternate power bar.
 	 @name AlternatePower
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current alternate power.
 	 @return A boolean value for the result of the comparison.
      */
@@ -3252,8 +2891,6 @@ export class OvaleConditions {
     /** Get the current amount of astral power for balance druids.
 	 @name AstralPower
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current runic power.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -3271,8 +2908,6 @@ export class OvaleConditions {
     /**Get the current amount of stored Chi for monks.
 	 @name Chi
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The amount of stored Chi.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -3289,8 +2924,6 @@ export class OvaleConditions {
     /**  Get the number of combo points for a feral druid or a rogue.
      @name ComboPoints
      @paramsig number or boolean
-     @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-     @param number Optional. The number to compare against.
      @return The number of combo points.
      @return A boolean value for the result of the comparison.
      @usage
@@ -3306,8 +2939,6 @@ export class OvaleConditions {
     /**Get the current amount of energy for feral druids, non-mistweaver monks, and rogues.
 	 @name Energy
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current energy.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -3325,8 +2956,6 @@ export class OvaleConditions {
     /**Get the current amount of focus for hunters.
 	 @name Focus
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current focus.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -3359,8 +2988,6 @@ export class OvaleConditions {
     /** Get the current amount of holy power for a paladin.
 	 @name HolyPower
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The amount of holy power.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -3393,8 +3020,6 @@ export class OvaleConditions {
     /**  Get the current level of mana of the target.
 	 @name Mana
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3444,8 +3069,6 @@ export class OvaleConditions {
     /** Get the current amount of rage for guardian druids and warriors.
 	 @name Rage
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current rage.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -3463,8 +3086,6 @@ export class OvaleConditions {
     /** Get the current amount of runic power for death knights.
 	 @name RunicPower
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current runic power.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -3482,8 +3103,6 @@ export class OvaleConditions {
     /** Get the current number of Soul Shards for warlocks.
 	 @name SoulShards
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of Soul Shards.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -3513,8 +3132,6 @@ export class OvaleConditions {
     /** Get the number of lacking resource points for a full alternate power bar, between 0 and maximum alternate power, of the target.
 	 @name AlternatePowerDeficit
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3537,8 +3154,6 @@ export class OvaleConditions {
     /** Get the number of lacking resource points for a full runic power bar, between 0 and maximum runic power, of the target.
 	 @name AstralPowerDeficit
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3561,8 +3176,6 @@ export class OvaleConditions {
     /**  Get the number of lacking resource points for full chi, between 0 and maximum chi, of the target.
 	 @name ChiDeficit
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3602,8 +3215,6 @@ export class OvaleConditions {
     /** Get the number of lacking resource points for a full energy bar, between 0 and maximum energy, of the target.
 	 @name EnergyDeficit
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3629,8 +3240,6 @@ export class OvaleConditions {
     /** Get the number of lacking resource points for a full focus bar, between 0 and maximum focus, of the target.
 	 @name FocusDeficit
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3660,8 +3269,6 @@ export class OvaleConditions {
     /** Get the number of lacking resource points for full holy power, between 0 and maximum holy power, of the target.
 	 @name HolyPowerDeficit
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3684,8 +3291,6 @@ export class OvaleConditions {
     /**  Get the number of lacking resource points for a full mana bar, between 0 and maximum mana, of the target.
 	 @name ManaDeficit
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3713,8 +3318,6 @@ export class OvaleConditions {
     /** Get the number of lacking resource points for a full rage bar, between 0 and maximum rage, of the target.
 	 @name RageDeficit
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3732,8 +3335,6 @@ export class OvaleConditions {
     /** Get the number of lacking resource points for a full runic power bar, between 0 and maximum runic power, of the target.
 	 @name RunicPowerDeficit
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3756,8 +3357,6 @@ export class OvaleConditions {
     /**  Get the number of lacking resource points for full soul shards, between 0 and maximum soul shards, of the target.
 	 @name SoulShardsDeficit
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3780,8 +3379,6 @@ export class OvaleConditions {
     /** Get the current percent level of mana (between 0 and 100) of the target.
 	 @name ManaPercent
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3803,8 +3400,6 @@ export class OvaleConditions {
 	 Alternate power is the resource tracked by the alternate power bar in certain boss fights.
 	 @name MaxAlternatePower
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3834,8 +3429,6 @@ export class OvaleConditions {
     /** Get the maximum amount of Chi of the target.
 	 @name MaxChi
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3859,8 +3452,6 @@ l    */
     /** Get the maximum amount of energy of the target.
 	 @name MaxEnergy
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3878,8 +3469,6 @@ l    */
     /**  Get the maximum amount of focus of the target.
 	 @name MaxFocus
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3904,8 +3493,6 @@ l    */
     /** Get the maximum amount of Holy Power of the target.
 	 @name MaxHolyPower
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3928,8 +3515,6 @@ l    */
     /** Get the maximum amount of mana of the target.
 	 @name MaxMana
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3956,8 +3541,6 @@ l    */
     /** Get the maximum amount of rage of the target.
 	 @name MaxRage
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3975,8 +3558,6 @@ l    */
     /**  Get the maximum amount of Runic Power of the target.
 	 @name MaxRunicPower
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -3999,8 +3580,6 @@ l    */
     /** Get the maximum amount of Soul Shards of the target.
 	 @name MaxSoulShards
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -4023,8 +3602,6 @@ l    */
     /** Get the maximum amount of Arcane Charges of the target.
 	 @name MaxArcaneCharges
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -4052,11 +3629,7 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) {
-        const [spell, comparator, limit] = [
-            <number>positionalParams[1],
-            <string>positionalParams[2],
-            <number>positionalParams[3],
-        ];
+        const spell = <number>positionalParams[1];
         const spellId = this.OvaleSpellBook.getKnownSpellId(spell);
         const [target] = this.ParseCondition(
             positionalParams,
@@ -4072,7 +3645,7 @@ l    */
                 target,
                 maxCost
             )) || [0];
-        return Compare(value, comparator, limit);
+        return Compare(value);
     }
 
     /** Get the amount of energy required to cast the given spell.
@@ -4080,8 +3653,6 @@ l    */
 	 @name EnergyCost
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param max Optional. Set max=1 to return the maximum energy cost for the spell.
 	     Defaults to max=0.
 	     Valid values: 0, 1
@@ -4103,8 +3674,6 @@ l    */
 	 @name FocusCost
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param max Optional. Set max=1 to return the maximum focus cost for the spell.
 	     Defaults to max=0.
 	     Valid values: 0, 1
@@ -4127,8 +3696,6 @@ l    */
 	 @name ManaCost
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param max Optional. Set max=1 to return the maximum mana cost for the spell.
 	     Defaults to max=0.
 	     Valid values: 0, 1
@@ -4150,8 +3717,6 @@ l    */
 	 @name RageCost
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param max Optional. Set max=1 to return the maximum rage cost for the spell.
 	     Defaults to max=0.
 	     Valid values: 0, 1
@@ -4173,8 +3738,6 @@ l    */
 	 @name RunicPowerCost
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param max Optional. Set max=1 to return the maximum runic power cost for the spell.
 	     Defaults to max=0.
 	     Valid values: 0, 1
@@ -4336,8 +3899,6 @@ l    */
     /**  Get the result of the target's level minus the player's level. This number may be negative.
 	 @name RelativeLevel
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -4354,7 +3915,6 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         let value, level;
         if (target == "player") {
@@ -4367,7 +3927,7 @@ l    */
         } else {
             value = level - this.OvalePaperDoll.level;
         }
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     private Refreshable = (
@@ -4401,8 +3961,6 @@ l    */
     /** Get the remaining cast time in seconds of the target's current spell cast.
 	 @name RemainingCastTime
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -4418,21 +3976,12 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         let [, , , startTime, endTime] = UnitCastingInfo(target);
         if (startTime && endTime) {
             startTime = startTime / 1000;
             endTime = endTime / 1000;
-            return TestValue(
-                startTime,
-                endTime,
-                0,
-                endTime,
-                -1,
-                comparator,
-                limit
-            );
+            return TestValue(startTime, endTime, 0, endTime, -1);
         }
         return [];
     };
@@ -4440,8 +3989,6 @@ l    */
     /**  Get the current number of active and regenerating (fractional) runes of the given type for death knights.
 	 @name Rune
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of runes.
 	 @return A boolean value for the result of the comparison.
 	 @see RuneCount
@@ -4453,7 +4000,6 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const [count, startCooldown, endCooldown] = this.OvaleRunes.RuneCount(
             atTime
         );
@@ -4461,17 +4007,9 @@ l    */
             const origin = startCooldown;
             const rate = 1 / (endCooldown - startCooldown);
             const [start, ending] = [startCooldown, INFINITY];
-            return TestValue(
-                start,
-                ending,
-                count,
-                origin,
-                rate,
-                comparator,
-                limit
-            );
+            return TestValue(start, ending, count, origin, rate);
         }
-        return Compare(count, comparator, limit);
+        return Compare(count);
     };
 
     private RuneDeficit = (
@@ -4479,7 +4017,6 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const [count, startCooldown, endCooldown] = this.OvaleRunes.RuneDeficit(
             atTime
         );
@@ -4487,24 +4024,14 @@ l    */
             const origin = startCooldown;
             const rate = -1 / (endCooldown - startCooldown);
             const [start, ending] = [startCooldown, INFINITY];
-            return TestValue(
-                start,
-                ending,
-                count,
-                origin,
-                rate,
-                comparator,
-                limit
-            );
+            return TestValue(start, ending, count, origin, rate);
         }
-        return Compare(count, comparator, limit);
+        return Compare(count);
     };
 
     /**  Get the current number of active runes of the given type for death knights.
 	 @name RuneCount
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param death Optional. Set death=1 to include all active death runes in the count. Set death=0 to exclude all death runes.
 	     Defaults to unset.
 	     Valid values: unset, 0, 1
@@ -4520,23 +4047,20 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const [count, startCooldown, endCooldown] = this.OvaleRunes.RuneCount(
             atTime
         );
         if (startCooldown < INFINITY) {
             const [start, ending] = [startCooldown, endCooldown];
-            return TestValue(start, ending, count, start, 0, comparator, limit);
+            return TestValue(start, ending, count, start, 0);
         }
-        return Compare(count, comparator, limit);
+        return Compare(count);
     };
 
     /**  Get the number of seconds before the player reaches the given amount of runes.
 	 @name TimeToRunes
 	 @paramsig number or boolean
 	 @param runes. The amount of runes to reach.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -4547,16 +4071,12 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [runes, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const runes = positionalParams[1];
         let seconds = this.OvaleRunes.GetRunesCooldown(atTime, runes);
         if (seconds < 0) {
             seconds = 0;
         }
-        return Compare(seconds, comparator, limit);
+        return Compare(seconds);
     };
 
     /**  Returns the value of the given snapshot stat.
@@ -4568,13 +4088,9 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) {
-        const [comparator, limit] = [
-            <string>positionalParams[1],
-            <number>positionalParams[2],
-        ];
         const value =
             this.OvalePaperDoll.GetState(atTime)[statName] || defaultValue;
-        return Compare(value, comparator, limit);
+        return Compare(value);
     }
 
     /**  Returns the critical strike chance of the given snapshot stat.
@@ -4586,23 +4102,17 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) {
-        const [comparator, limit] = [
-            <string>positionalParams[1],
-            <number>positionalParams[2],
-        ];
         let value =
             this.OvalePaperDoll.GetState(atTime)[statName] || defaultValue;
         if (namedParams.unlimited != 1 && value > 100) {
             value = 100;
         }
-        return Compare(value, comparator, limit);
+        return Compare(value);
     }
 
     /** Get the current agility of the player.
 	 @name Agility
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current agility.
 	 @return A boolean value for the result of the comparison.
      */
@@ -4623,8 +4133,6 @@ l    */
     /** Get the current attack power of the player.
 	 @name AttackPower
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current attack power.
 	 @return A boolean value for the result of the comparison.
      */
@@ -4645,8 +4153,6 @@ l    */
     /** Get the current critical strike rating of the player.
 	 @name CritRating
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current critical strike rating.
 	 @return A boolean value for the result of the comparison.
      */
@@ -4667,8 +4173,6 @@ l    */
     /** Get the current haste rating of the player.
 	 @name HasteRating
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current haste rating.
 	 @return A boolean value for the result of the comparison.
      */
@@ -4689,8 +4193,6 @@ l    */
     /** Get the current intellect of the player.
 	 @name Intellect
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current intellect.
 	 @return A boolean value for the result of the comparison.
      */
@@ -4713,8 +4215,6 @@ l    */
 	 or a percent-increase to chance to trigger some effect.
 	 @name MasteryEffect
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current mastery effect.
 	 @return A boolean value for the result of the comparison.
      */
@@ -4735,8 +4235,6 @@ l    */
     /** Get the current mastery rating of the player.
 	 @name MasteryRating
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current mastery rating.
 	 @return A boolean value for the result of the comparison.
      */
@@ -4757,8 +4255,6 @@ l    */
     /** Get the current melee critical strike chance of the player.
 	 @name MeleeCritChance
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param unlimited Optional. Set unlimited=1 to allow critical strike chance to exceed 100%.
 	     Defaults to unlimited=0.
 	     Valid values: 0, 1
@@ -4782,8 +4278,6 @@ l    */
     /**  Get the current percent increase to melee haste of the player.
 	 @name MeleeAttackSpeedPercent
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current percent increase to melee haste.
 	 @return A boolean value for the result of the comparison.
      */
@@ -4804,8 +4298,6 @@ l    */
     /** Get the current ranged critical strike chance of the player.
 	 @name RangedCritChance
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param unlimited Optional. Set unlimited=1 to allow critical strike chance to exceed 100%.
 	     Defaults to unlimited=0.
 	     Valid values: 0, 1
@@ -4829,8 +4321,6 @@ l    */
     /**  Get the current spell critical strike chance of the player.
 	 @name SpellCritChance
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param unlimited Optional. Set unlimited=1 to allow critical strike chance to exceed 100%.
 	     Defaults to unlimited=0.
 	     Valid values: 0, 1
@@ -4854,8 +4344,6 @@ l    */
     /**  Get the current percent increase to spell haste of the player.
 	 @name SpellCastSpeedPercent
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current percent increase to spell haste.
 	 @return A boolean value for the result of the comparison.
      */
@@ -4876,8 +4364,6 @@ l    */
     /** Get the current spellpower of the player.
 	 @name Spellpower
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current spellpower.
 	 @return A boolean value for the result of the comparison.
      */
@@ -4898,8 +4384,6 @@ l    */
     /** Get the current stamina of the player.
 	 @name Stamina
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current stamina.
 	 @return A boolean value for the result of the comparison.
      */
@@ -4920,8 +4404,6 @@ l    */
     /** Get the current strength of the player.
 	 @name Strength
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The current strength.
 	 @return A boolean value for the result of the comparison.
      */
@@ -4972,8 +4454,6 @@ l    */
 	 If the target is at running speed, then this condition returns 100.
 	 @name Speed
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=player.
 	     Valid values: player, target, focus, pet.
@@ -4988,18 +4468,15 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const value = (GetUnitSpeed(target) * 100) / 7;
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /** Get the cooldown in seconds on a spell before it gains another charge.
 	 @name SpellChargeCooldown
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @return A boolean value for the result of the comparison.
 	 @see SpellCharges
@@ -5012,11 +4489,7 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const spellId = positionalParams[1];
         const [
             charges,
             maxCharges,
@@ -5024,25 +4497,16 @@ l    */
             duration,
         ] = this.OvaleCooldown.GetSpellCharges(spellId, atTime);
         if (charges && charges < maxCharges) {
-            return TestValue(
-                start,
-                start + duration,
-                duration,
-                start,
-                -1,
-                comparator,
-                limit
-            );
+			const ending = start + duration;
+            return TestValue(start, ending, duration, start, -1);
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     /** Get the number of charges of the spell.
 	 @name SpellCharges
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param count Optional. Sets whether a count or a fractional value is returned.
 	     Defaults to count=1.
 	     Valid values: 0, 1.
@@ -5058,11 +4522,7 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const spellId = positionalParams[1];
         const [
             charges,
             maxCharges,
@@ -5075,20 +4535,16 @@ l    */
                 INFINITY,
                 charges + 1,
                 start + duration,
-                1 / duration,
-                comparator,
-                limit
+                1 / duration
             );
         }
-        return Compare(charges, comparator, limit);
+        return Compare(charges);
     };
 
     /** Get the number of seconds for a full recharge of the spell.
      * @name SpellFullRecharge
      * @paramsig number or boolean
      * @param id The spell ID.
-     * @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-     * @param number Optional. The number to compare against.
      * @usage
      * if SpellFullRecharge(dire_frenzy) < GCD()
      *     Spell(dire_frenzy) */
@@ -5098,8 +4554,6 @@ l    */
         atTime: number
     ) => {
         const spellId = positionalParams[1];
-        const comparator = positionalParams[2];
-        const limit = positionalParams[3];
         const [
             charges,
             maxCharges,
@@ -5109,17 +4563,9 @@ l    */
         if (charges && charges < maxCharges) {
             const duration = (maxCharges - charges) * dur;
             const ending = start + duration;
-            return TestValue(
-                start,
-                ending,
-                ending - start,
-                start,
-                -1,
-                comparator,
-                limit
-            );
+            return TestValue(start, ending, duration, start, -1);
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     /** Get the number of seconds before any of the listed spells are ready for use.
@@ -5127,8 +4573,6 @@ l    */
 	 @paramsig number or boolean
 	 @param id The spell ID.
 	 @param ... Optional. Additional spell IDs.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @return A boolean value for the result of the comparison.
 	 @see TimeToSpell
@@ -5141,8 +4585,7 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        let comparator: string | undefined, limit: number | undefined;
-        const usable = namedParams.usable == 1;
+        const usable = (namedParams.usable == 1);
         const [target] = this.ParseCondition(
             positionalParams,
             namedParams,
@@ -5151,11 +4594,8 @@ l    */
         const targetGuid = this.OvaleGUID.UnitGUID(target);
         if (!targetGuid) return [];
         let earliest = INFINITY;
-        for (const [i, spellId] of ipairs(positionalParams)) {
-            if (isComparator(spellId)) {
-                [comparator, limit] = [spellId, positionalParams[i + 1]];
-                break;
-            } else if (
+        for (const [, spellId] of ipairs(positionalParams)) {
+            if (
                 !usable ||
                 this.OvaleSpells.IsUsableSpell(spellId, atTime, targetGuid)
             ) {
@@ -5173,19 +4613,17 @@ l    */
             }
         }
         if (earliest == INFINITY) {
-            return Compare(0, comparator, limit);
+            return Compare(0);
         } else if (earliest > 0) {
-            return TestValue(0, INFINITY, 0, earliest, -1, comparator, limit);
+            return TestValue(0, INFINITY, 0, earliest, -1);
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     /** Get the cooldown duration in seconds for a given spell.
 	 @name SpellCooldownDuration
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target of the spell. The target may also be given as a prefix to the condition.
 	     Defaults to target=target.
 	     Valid values: player, target, focus, pet.
@@ -5197,11 +4635,7 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const spellId = positionalParams[1];
         const [target] = this.ParseCondition(
             positionalParams,
             namedParams,
@@ -5212,15 +4646,13 @@ l    */
             atTime,
             target
         );
-        return Compare(duration, comparator, limit);
+        return Compare(duration);
     };
 
     /** Get the recharge duration in seconds for a given spell.
 	 @name SpellRechargeDuration
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target of the spell. The target may also be given as a prefix to the condition.
 	     Defaults to target=target.
 	     Valid values: player, target, focus, pet.
@@ -5232,11 +4664,7 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const spellId = positionalParams[1];
         const [target] = this.ParseCondition(
             positionalParams,
             namedParams,
@@ -5250,7 +4678,7 @@ l    */
                 atTime,
                 target
             );
-        return Compare(duration, comparator, limit);
+        return Compare(duration);
     };
 
     /** Get data for the given spell defined by SpellInfo(...)
@@ -5259,8 +4687,6 @@ l    */
 	 @param id The spell ID.
 	 @param key The name of the data set by SpellInfo(...).
 	     Valid values are any alphanumeric string.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number data associated with the given key.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -5272,17 +4698,15 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, key, comparator, limit] = [
+        const [spellId, key] = [
             <number>positionalParams[1],
             <keyof SpellInfo>positionalParams[2],
-            <string>positionalParams[3],
-            <number>positionalParams[4],
         ];
         const si = this.OvaleData.spellInfo[spellId];
         if (si) {
             const value = si[key];
             if (value) {
-                return Compare(<number>value, comparator, limit);
+                return Compare(<number>value);
             }
         }
         return [];
@@ -5294,8 +4718,6 @@ l    */
 	 @param id The spell ID.
 	 @param key The name of the data set by SpellInfo(...).
 	     Valid values are any alphanumeric string.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number data associated with the given key after calculations
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -5307,11 +4729,9 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, key, comparator, limit] = [
+        const [spellId, key] = [
             <number>positionalParams[1],
             <SpellInfoProperty>positionalParams[2],
-            <string>positionalParams[3],
-            <number>positionalParams[4],
         ];
         const value = this.OvaleData.GetSpellInfoProperty(
             spellId,
@@ -5320,7 +4740,7 @@ l    */
             undefined
         );
         if (value) {
-            return Compare(<number>value, comparator, limit);
+            return Compare(<number>value);
         }
         return [];
     };
@@ -5329,8 +4749,6 @@ l    */
 	 @name SpellCount
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of times a spell can be cast.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -5342,13 +4760,9 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const spellId = positionalParams[1];
         const spellCount = this.OvaleSpells.GetSpellCount(spellId);
-        return Compare(spellCount, comparator, limit);
+        return Compare(spellCount);
     };
 
     /** Test if the given spell is in the spellbook.
@@ -5377,8 +4791,6 @@ l    */
 	 @name SpellMaxCharges
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param count Optional. Sets whether a count or a fractional value is returned.
 	     Defaults to count=1.
 	     Valid values: 0, 1.
@@ -5394,11 +4806,7 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const spellId = positionalParams[1];
         let [, maxCharges, ,] = this.OvaleCooldown.GetSpellCharges(
             spellId,
             atTime
@@ -5407,7 +4815,7 @@ l    */
             return [];
         }
         maxCharges = maxCharges || 1;
-        return Compare(maxCharges, comparator, limit);
+        return Compare(maxCharges);
     };
 
     /** Test if the given spell is usable.
@@ -5478,8 +4886,6 @@ l    */
 	 @param hand Optional. Sets which hand weapon's melee swing.
 	     If no hand is specified, then return the time elapsed since the previous swing of either hand's weapon.
 	     Valid values: main, off.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @return A boolean value for the result of the comparison.
 	 @see NextSwing
@@ -5489,18 +4895,10 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const swing = positionalParams[1];
-        let comparator, limit;
-        let start;
-        if ((swing && swing == "main") || swing == "off") {
-            [comparator, limit] = [positionalParams[2], positionalParams[3]];
-            start = 0;
-        } else {
-            [comparator, limit] = [positionalParams[1], positionalParams[2]];
-            start = 0;
-        }
+        //const swing = positionalParams[1];
+        const start = 0;
         OneTimeMessage("Warning: 'LastSwing()' is not implemented.");
-        return TestValue(start, INFINITY, 0, start, 1, comparator, limit);
+        return TestValue(start, INFINITY, 0, start, 1);
     };
 
     /** Get the time in seconds until the player's next melee swing (white attack).
@@ -5509,8 +4907,6 @@ l    */
 	 @param hand Optional. Sets which hand weapon's melee swing.
 	     If no hand is specified, then return the time until the next swing of either hand's weapon.
 	     Valid values: main, off.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds
 	 @return A boolean value for the result of the comparison.
 	 @see LastSwing
@@ -5520,18 +4916,10 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const swing = positionalParams[1];
-        let comparator, limit;
-        let ending;
-        if ((swing && swing == "main") || swing == "off") {
-            [comparator, limit] = [positionalParams[2], positionalParams[3]];
-            ending = 0;
-        } else {
-            [comparator, limit] = [positionalParams[1], positionalParams[2]];
-            ending = 0;
-        }
+        //const swing = positionalParams[1];
+        const ending = 0;
         OneTimeMessage("Warning: 'NextSwing()' is not implemented.");
-        return TestValue(0, ending, 0, ending, -1, comparator, limit);
+        return TestValue(0, ending, 0, ending, -1);
     };
 
     /** Test if the given talent is active.
@@ -5559,8 +4947,6 @@ l    */
 	 @name TalentPoints
 	 @paramsig number or boolean
 	 @param talent Talent to inspect.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of talent points.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -5571,13 +4957,9 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [talent, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const talent = positionalParams[1];
         const value = this.OvaleSpellBook.GetTalentPoints(talent);
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /** Test if the player is the in-game target of the target.
@@ -5608,8 +4990,6 @@ l    */
 	 This is a number between 0 (no threat) and 100 (will become the primary aggro target).
 	 @name Threat
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
 	     Defaults to target=target.
 	     Valid values: player, target, focus, pet.
@@ -5624,22 +5004,19 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const [target] = this.ParseCondition(
             positionalParams,
             namedParams,
             "target"
         );
         const [, , value] = UnitDetailedThreatSituation("player", target);
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /** Get the number of seconds between ticks of a periodic aura on a target.
 	 @name TickTime
 	 @paramsig number or boolean
 	 @param id The spell ID of the aura or the name of a spell list.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param filter Optional. The type of aura to check.
 	     Default is any.
 	     Valid values: any, buff, debuff
@@ -5655,11 +5032,7 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [auraId, comparator, limit] = [
-            <number>positionalParams[1],
-            <string>positionalParams[2],
-            <number>positionalParams[3],
-        ];
+        const auraId = <number>positionalParams[1];
         const [target, filter, mine] = this.ParseCondition(
             positionalParams,
             namedParams
@@ -5681,9 +5054,9 @@ l    */
             );
         }
         if (tickTime && tickTime > 0) {
-            return Compare(tickTime, comparator, limit);
+            return Compare(tickTime);
         }
-        return Compare(INFINITY, comparator, limit);
+        return Compare(INFINITY);
     };
 
     private CurrentTickTime = (
@@ -5691,11 +5064,7 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [auraId, comparator, limit] = [
-            <number>positionalParams[1],
-            <string>positionalParams[2],
-            <number>positionalParams[3],
-        ];
+        const auraId = <number>positionalParams[1];
         const [target, filter, mine] = this.ParseCondition(
             positionalParams,
             namedParams
@@ -5713,15 +5082,13 @@ l    */
         } else {
             tickTime = 0;
         }
-        return Compare(tickTime, comparator, limit);
+        return Compare(tickTime);
     };
 
     /** Get the remaining number of ticks of a periodic aura on a target.
 	 @name TicksRemaining
 	 @paramsig number or boolean
 	 @param id The spell ID of the aura or the name of a spell list.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param filter Optional. The type of aura to check.
 	     Default is any.
 	     Valid values: any, buff, debuff
@@ -5740,11 +5107,7 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [auraId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const auraId = positionalParams[1];
         const [target, filter, mine] = this.ParseCondition(
             positionalParams,
             namedParams
@@ -5764,18 +5127,10 @@ l    */
                 aura.tick,
             ];
             if (tick && tick > 0) {
-                return TestValue(
-                    gain,
-                    INFINITY,
-                    1,
-                    ending,
-                    -1 / tick,
-                    comparator,
-                    limit
-                );
+                return TestValue(gain, INFINITY, 1, ending, -1 / tick);
             }
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     /** Gets the remaining time until the next tick */
@@ -5784,11 +5139,7 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [auraId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const auraId = positionalParams[1];
         const [target, filter, mine] = this.ParseCondition(
             positionalParams,
             namedParams
@@ -5807,18 +5158,16 @@ l    */
                 this.OvaleAura.GetTickLength(auraId, this.OvalePaperDoll.next);
             const remainingTime = tick - (atTime - lastTickTime);
             if (remainingTime && remainingTime > 0) {
-                return Compare(remainingTime, comparator, limit);
+                return Compare(remainingTime);
             }
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     /** Get the number of seconds elapsed since the player cast the given spell.
 	 @name TimeSincePreviousSpell
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -5829,23 +5178,17 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spell, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const spell = positionalParams[1];
         const spellId = this.OvaleSpellBook.getKnownSpellId(spell);
         if (!spellId) return [];
         const t = this.OvaleFuture.TimeOfLastCast(spellId, atTime);
-        return TestValue(0, INFINITY, 0, t, 1, comparator, limit);
+        return TestValue(0, INFINITY, 0, t, 1);
     };
 
     /** Get the time in seconds until the next scheduled Bloodlust cast.
 	 Not implemented, always returns 3600 seconds.
 	 @name TimeToBloodlust
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @return A boolean value for the result of the comparison.
      */
@@ -5854,13 +5197,8 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
         const value = 3600;
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     private TimeToEclipse = (
@@ -5868,14 +5206,9 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
         const value = 3600 * 24 * 7;
         OneTimeMessage("Warning: 'TimeToEclipse()' is not implemented.");
-        return TestValue(0, INFINITY, value, atTime, -1, comparator, limit);
+        return TestValue(0, INFINITY, value, atTime, -1);
     };
 
     /** Get the number of seconds before the player reaches the given power level.
@@ -5883,8 +5216,6 @@ l    */
     private TimeToPower(
         powerType: PowerType,
         level: number,
-        comparator: string,
-        limit: number,
         atTime: number
     ) {
         level = level || 0;
@@ -5895,19 +5226,11 @@ l    */
             atTime
         );
         if (seconds == 0) {
-            return Compare(0, comparator, limit);
+            return Compare(0);
         } else if (seconds < INFINITY) {
-            return TestValue(
-                0,
-                atTime + seconds,
-                seconds,
-                atTime,
-                -1,
-                comparator,
-                limit
-            );
+            return TestValue(0, atTime + seconds, seconds, atTime, -1);
         } else {
-            return Compare(INFINITY, comparator, limit);
+            return Compare(INFINITY);
         }
     }
 
@@ -5915,8 +5238,6 @@ l    */
 	 @name TimeToEnergy
 	 @paramsig number or boolean
 	 @param level. The level of energy to reach.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @see TimeToEnergyFor, TimeToMaxEnergy
 	 @return A boolean value for the result of the comparison.
@@ -5928,19 +5249,13 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [level, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
-        return this.TimeToPower("energy", level, comparator, limit, atTime);
+        const level = positionalParams[1];
+        return this.TimeToPower("energy", level, atTime);
     };
 
     /** Get the number of seconds before the player reaches maximum energy for feral druids, non-mistweaver monks and rogues.
 	 @name TimeToMaxEnergy
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @see TimeToEnergy, TimeToEnergyFor
 	 @return A boolean value for the result of the comparison.
@@ -5953,17 +5268,14 @@ l    */
         atTime: number
     ) => {
         const powerType = "energy";
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const level = this.OvalePower.current.maxPower[powerType] || 0;
-        return this.TimeToPower(powerType, level, comparator, limit, atTime);
+        return this.TimeToPower(powerType, level, atTime);
     };
 
     /** Get the number of seconds before the player reaches the given focus level for hunters.
 	 @name TimeToFocus
 	 @paramsig number or boolean
 	 @param level. The level of focus to reach.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @see TimeToFocusFor, TimeToMaxFocus
 	 @return A boolean value for the result of the comparison.
@@ -5975,19 +5287,13 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [level, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
-        return this.TimeToPower("focus", level, comparator, limit, atTime);
+        const level = positionalParams[1];
+        return this.TimeToPower("focus", level, atTime);
     };
 
     /** Get the number of seconds before the player reaches maximum focus for hunters.
 	 @name TimeToMaxFocus
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @see TimeToFocus, TimeToFocusFor
 	 @return A boolean value for the result of the comparison.
@@ -6000,9 +5306,8 @@ l    */
         atTime: number
     ) => {
         const powerType: PowerType = "focus";
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const level = this.OvalePower.current.maxPower[powerType] || 0;
-        return this.TimeToPower(powerType, level, comparator, limit, atTime);
+        return this.TimeToPower(powerType, level, atTime);
     };
 
     private TimeToMaxMana = (
@@ -6011,9 +5316,8 @@ l    */
         atTime: number
     ) => {
         const powerType: PowerType = "mana";
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const level = this.OvalePower.current.maxPower[powerType] || 0;
-        return this.TimeToPower(powerType, level, comparator, limit, atTime);
+        return this.TimeToPower(powerType, level, atTime);
     };
 
     private TimeToPowerFor(
@@ -6022,11 +5326,7 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ): ConditionResult {
-        const [spellId, comparator, limit] = [
-            <number>positionalParams[1],
-            <string>positionalParams[2],
-            <number>positionalParams[3],
-        ];
+        const spellId = <number>positionalParams[1];
         const [target] = this.ParseCondition(
             positionalParams,
             namedParams,
@@ -6041,27 +5341,17 @@ l    */
             powerType
         );
         if (seconds == 0) {
-            return Compare(0, comparator, limit);
+            return Compare(0);
         } else if (seconds < INFINITY) {
-            return TestValue(
-                0,
-                atTime + seconds,
-                seconds,
-                atTime,
-                -1,
-                comparator,
-                limit
-            );
+            return TestValue(0, atTime + seconds, seconds, atTime, -1);
         } else {
-            return Compare(INFINITY, comparator, limit);
+            return Compare(INFINITY);
         }
     }
     /** Get the number of seconds before the player has enough energy to cast the given spell.
 	 @name TimeToEnergyFor
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target of the spell. The target may also be given as a prefix to the condition.
 	     Defaults to target=target.
 	     Valid values: player, target, focus, pet.
@@ -6086,8 +5376,6 @@ l    */
 	 @name TimeToFocusFor
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @return A boolean value for the result of the comparison.
 	 @see TimeToFocusFor
@@ -6109,8 +5397,6 @@ l    */
 	 @name TimeToSpell
 	 @paramsig number or boolean
 	 @param id The spell ID.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target of the spell. The target may also be given as a prefix to the condition.
 	     Defaults to target=target.
 	     Valid values: player, target, focus, pet.
@@ -6122,32 +5408,25 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
         /*
         let [target] = private ParseCondition = (positionalParams, namedParams, "target");
         let seconds = OvaleSpells.GetTimeToSpell(spellId, atTime, OvaleGUID.UnitGUID(target));
         if (seconds == 0) {
-            return Compare(0, comparator, limit);
+            return Compare(0);
         } else if (seconds < INFINITY) {
-            return TestValue(0, atTime + seconds, seconds, atTime, -1, comparator, limit);
+            return TestValue(0, atTime + seconds, seconds, atTime, -1);
         } else {
-            return Compare(INFINITY, comparator, limit);
+            return Compare(INFINITY);
         }
         */
         OneTimeMessage("Warning: 'TimeToSpell()' is not implemented.");
-        return TestValue(0, INFINITY, 0, atTime, -1, comparator, limit);
+        return TestValue(0, INFINITY, 0, atTime, -1);
     };
     /** Get the time scaled by the specified haste type, defaulting to spell haste.
 	 For example, if a DoT normally ticks every 3 seconds and is scaled by spell haste, then it ticks every TimeWithHaste(3 haste=spell) seconds.
 	 @name TimeWithHaste
 	 @paramsig number or boolean
 	 @param time The time in seconds.
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param haste Optional. Sets whether "time" should be lengthened or shortened due to haste.
 	     Defaults to haste=spell.
 	     Valid values: melee, spell.
@@ -6162,14 +5441,10 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [seconds, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const seconds = positionalParams[1];
         const haste = (namedParams.haste as HasteType) || "spell";
         const value = this.GetHastedTime(seconds, haste);
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /** Test if the totem has expired.
@@ -6231,8 +5506,6 @@ l    */
 	 @name TotemRemaining
 	 @paramsig number or boolean
 	 @param id The ID of the spell used to summon the totem or one of the four shaman totem categories (air, earth, fire, water).
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The number of seconds.
 	 @return A boolean value for the result of the comparison.
 	 @see TotemExpires, TotemPresent
@@ -6244,11 +5517,7 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [id, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            <number>positionalParams[3],
-        ];
+        const id = positionalParams[1];
         const [count, start, ending] = this.OvaleTotem.GetTotemInfo(id, atTime);
         if (
             count !== undefined &&
@@ -6256,9 +5525,9 @@ l    */
             ending !== undefined &&
             count > 0
         ) {
-            return TestValue(start, ending, 0, ending, -1, comparator, limit);
+            return TestValue(start, ending, 0, ending, -1);
         }
-        return Compare(0, comparator, limit);
+        return Compare(0);
     };
 
     /** Check if a tracking is enabled
@@ -6288,8 +5557,6 @@ l    */
 	 This is a fixed guess at 0s or the travel time of the spell in the spell information if given.
 	 @name TravelTime
 	 @paramsig number or boolean
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @param target Optional. Sets the target of the spell. The target may also be given as a prefix to the condition.
 	     Defaults to target=target.
 	     Valid values: player, target, focus, pet.
@@ -6304,11 +5571,7 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [spellId, comparator, limit] = [
-            positionalParams[1],
-            positionalParams[2],
-            positionalParams[3],
-        ];
+        const spellId = positionalParams[1];
         //let target = private ParseCondition = (positionalParams, namedParams, "target");
         const si = spellId && this.OvaleData.spellInfo[spellId];
         let travelTime = 0;
@@ -6321,7 +5584,7 @@ l    */
                 travelTime = estimatedTravelTime;
             }
         }
-        return Compare(travelTime, comparator, limit);
+        return Compare(travelTime);
     };
 
     /**  A condition that always returns true.
@@ -6343,8 +5606,6 @@ l    */
 	 @param hand Optional. Sets which hand weapon.
 	     Defaults to main.
 	     Valid values: main, off
-	 @param operator Optional. Comparison operator: less, atMost, equal, atLeast, more.
-	 @param number Optional. The number to compare against.
 	 @return The weapon DPS.
 	 @return A boolean value for the result of the comparison.
 	 @usage
@@ -6358,19 +5619,15 @@ l    */
         atTime: number
     ) => {
         const hand = positionalParams[1];
-        let comparator, limit;
         let value = 0;
         if (hand == "offhand" || hand == "off") {
-            [comparator, limit] = [positionalParams[2], positionalParams[3]];
             value = this.OvalePaperDoll.current.offHandWeaponDPS || 0;
         } else if (hand == "mainhand" || hand == "main") {
-            [comparator, limit] = [positionalParams[2], positionalParams[3]];
             value = this.OvalePaperDoll.current.mainHandWeaponDPS || 0;
         } else {
-            [comparator, limit] = [positionalParams[1], positionalParams[2]];
             value = this.OvalePaperDoll.current.mainHandWeaponDPS || 0;
         }
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /** Test if a sigil is charging
@@ -6477,9 +5734,8 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [comparator, limit] = [positionalParams[1], positionalParams[2]];
         const value = this.OvaleDemonHunterSoulFragments.SoulFragments(atTime);
-        return Compare(value, comparator, limit);
+        return Compare(value);
     };
 
     /** Test if a specific dispel type is present.

--- a/src/states/conditions.ts
+++ b/src/states/conditions.ts
@@ -1,7 +1,6 @@
 import LibBabbleCreatureType from "@wowts/lib_babble-creature_type-3.0";
 import LibRangeCheck from "@wowts/lib_range_check-2.0";
 import {
-    Compare,
     ConditionFunction,
     ConditionResult,
     OvaleConditionClass,
@@ -202,7 +201,7 @@ export class OvaleConditions {
     ) => {
         const value = 0;
         OneTimeMessage("Warning: 'ArmorSetBonus()' is depreciated.  Returns 0");
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     private AzeriteEssenceIsMajor = (
@@ -241,7 +240,7 @@ export class OvaleConditions {
     ) => {
         const essenceId = positionalParams[1];
         const value = this.OvaleAzeriteEssence.EssenceRank(essenceId);
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /** Get the base duration of the aura in seconds if it is applied at the current time.
@@ -279,7 +278,7 @@ export class OvaleConditions {
                 this.OvalePaperDoll.next
             );
         }
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /** Get the value of a buff as a number.  Not all buffs return an amount.
@@ -336,7 +335,7 @@ export class OvaleConditions {
                 0
             );
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     /** Get the player's combo points for the given aura at the time the aura was applied on the target.
@@ -378,7 +377,7 @@ export class OvaleConditions {
                 0
             );
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     /** Get the number of seconds before a buff can be gained again.
@@ -450,7 +449,7 @@ export class OvaleConditions {
                 count = count + 1;
             }
         }
-        return Compare(count);
+        return ReturnConstant(count);
     };
 
     /** Get the duration in seconds of the cooldown before a buff can be gained again.
@@ -482,7 +481,7 @@ export class OvaleConditions {
         } else {
             minCooldown = 0;
         }
-        return Compare(minCooldown);
+        return ReturnConstant(minCooldown);
     };
 
     /** /** Get the total count of the given aura across all targets.
@@ -544,7 +543,7 @@ export class OvaleConditions {
                 rate
             );
         }
-        return Compare(count);
+        return ReturnConstant(count);
     };
 
     /** Get the current direction of an aura's stack count.
@@ -589,7 +588,7 @@ export class OvaleConditions {
                 0
             );
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     /** Get the total duration of the aura from when it was first applied to when it ended.
@@ -630,7 +629,7 @@ export class OvaleConditions {
                 0
             );
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     /** Test if an aura is expired, or will expire after a given number of seconds.
@@ -776,7 +775,7 @@ export class OvaleConditions {
             const gain = aura.gain || 0;
             return ReturnValueBetween(gain, INFINITY, 0, gain, 1);
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     private BuffImproved = (
@@ -786,7 +785,7 @@ export class OvaleConditions {
     ) => {
         let [, ,] = this.ParseCondition(positionalParams, namedParams);
         // TODO Not implemented
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     /** Get the player's persistent multiplier for the given aura at the time the aura was applied on the target.
@@ -830,7 +829,7 @@ export class OvaleConditions {
                 0
             );
         }
-        return Compare(1);
+        return ReturnConstant(1);
     };
 
     /** Get the remaining time in seconds on an aura.
@@ -870,7 +869,7 @@ export class OvaleConditions {
         if (aura && aura.ending >= atTime) {
             return ReturnValueBetween(aura.gain, INFINITY, 0, aura.ending, -1);
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     /** Get the remaining time in seconds before the aura expires across all targets.
@@ -914,7 +913,7 @@ export class OvaleConditions {
         if (count > 0) {
             return ReturnValueBetween(startFirst, INFINITY, 0, endingLast, -1);
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     /** Get the number of stacks of an aura on the target.
@@ -963,7 +962,7 @@ export class OvaleConditions {
                 0
             );
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     private maxStacks = (
@@ -974,7 +973,7 @@ export class OvaleConditions {
         const auraId = positionalParams[1] as number;
         const spellInfo = this.OvaleData.GetSpellInfo(auraId);
         const maxStacks = (spellInfo && spellInfo.max_stacks) || 0;
-        return Compare(maxStacks);
+        return ReturnConstant(maxStacks);
     };
 
     /** Get the total number of stacks of the given aura across all targets.
@@ -1027,7 +1026,7 @@ export class OvaleConditions {
                 0
             );
         }
-        return Compare(count);
+        return ReturnConstant(count);
     };
 
     /** Test if there is a stealable buff on the target.
@@ -1092,7 +1091,7 @@ export class OvaleConditions {
     ) => {
         const spellId = positionalParams[1];
         const castTime = this.OvaleSpellBook.GetCastTime(spellId) || 0;
-        return Compare(castTime);
+        return ReturnConstant(castTime);
     };
 
     /** Get the cast time in seconds of the spell for the player or the GCD for the player, whichever is greater.
@@ -1115,7 +1114,7 @@ export class OvaleConditions {
         const castTime = this.OvaleSpellBook.GetCastTime(spellId) || 0;
         const gcd = this.OvaleFuture.GetGCD(atTime);
         const t = (castTime > gcd && castTime) || gcd;
-        return Compare(t);
+        return ReturnConstant(t);
     };
 
     /** Test if the target is casting the given spell.
@@ -1352,7 +1351,7 @@ export class OvaleConditions {
     ) => {
         const counter = positionalParams[1];
         const value = this.OvaleFuture.GetCounter(counter, atTime);
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /** Test whether the target's creature family matches the given name.
@@ -1466,7 +1465,7 @@ export class OvaleConditions {
             }
         }
         value = critMultiplier * value;
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /**  Get the current estimated damage of a spell on the target.
@@ -1500,7 +1499,7 @@ export class OvaleConditions {
         if (si && si.physical == 1) {
             value = value * (1 - BossArmorDamageReduction(target));
         }
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /**  Get the total damage taken by the player in the previous time interval.
@@ -1524,7 +1523,7 @@ export class OvaleConditions {
             const [total] = this.OvaleDamageTaken.GetRecentDamage(interval);
             value = total;
         }
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /**  Get the magic damage taken by the player in the previous time interval.
@@ -1550,7 +1549,7 @@ export class OvaleConditions {
             );
             value = totalMagic;
         }
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /**  Get the physical damage taken by the player in the previous time interval.
@@ -1576,7 +1575,7 @@ export class OvaleConditions {
             );
             value = total - totalMagic;
         }
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     GetDiseases(
@@ -1628,7 +1627,7 @@ export class OvaleConditions {
         if (aura) {
             return ReturnValueBetween(aura.gain, INFINITY, 0, aura.ending, -1);
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     /**  Test if all diseases applied by the death knight are present on the target.
@@ -1712,7 +1711,7 @@ export class OvaleConditions {
     ) => {
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const value = (LibRangeCheck && LibRangeCheck.GetRange(target)) || 0;
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /**  Get the number of hostile enemies on the battlefield.
@@ -1749,7 +1748,7 @@ export class OvaleConditions {
         if (value < 1) {
             value = 1;
         }
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /** Get the amount of regenerated energy per second for feral druids, non-mistweaver monks, and rogues.
@@ -1770,7 +1769,7 @@ export class OvaleConditions {
             "energy",
             atTime
         );
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /** Get the remaining time in seconds the target is Enraged.
@@ -1801,7 +1800,7 @@ export class OvaleConditions {
         if (aura && aura.ending >= atTime) {
             return ReturnValueBetween(aura.gain, INFINITY, 0, aura.ending, -1);
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     /** Test if the target exists. The target may be alive or dead.
@@ -1857,7 +1856,7 @@ export class OvaleConditions {
             "focus",
             atTime
         );
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /** Get the amount of focus that would be regenerated during the cast time of the given spell for hunters.
@@ -1899,7 +1898,7 @@ export class OvaleConditions {
             }
             power = power + regenRate * 1.5 * seconds;
         }
-        return Compare(power);
+        return ReturnConstant(power);
     };
 
     /** Get the player's global cooldown in seconds.
@@ -1917,7 +1916,7 @@ export class OvaleConditions {
         atTime: number
     ) => {
         const value = this.OvaleFuture.GetGCD(atTime);
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /** Get the number of seconds before the player's global cooldown expires.
@@ -1954,7 +1953,7 @@ export class OvaleConditions {
                 return ReturnValueBetween(start, INFINITY, 0, ending, -1);
             }
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     private Glyph = (
@@ -2007,7 +2006,7 @@ export class OvaleConditions {
             const rate = (-1 * health) / timeToDie;
             return ReturnValueBetween(now, INFINITY, health, now, rate);
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     /** Get the current amount of health points of the target including absorbs.
@@ -2068,7 +2067,7 @@ export class OvaleConditions {
             const rate = health / timeToDie;
             return ReturnValueBetween(now, INFINITY, missing, now, rate);
         }
-        return Compare(maxHealth);
+        return ReturnConstant(maxHealth);
     };
 
     /** Get the current percent level of health of the target.
@@ -2099,7 +2098,7 @@ export class OvaleConditions {
             const rate = (-1 * healthPct) / timeToDie;
             return ReturnValueBetween(now, INFINITY, healthPct, now, rate);
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     /** Get the current effective percent level of health of the target (including absorbs).
@@ -2152,7 +2151,7 @@ export class OvaleConditions {
     ) => {
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const value = this.OvaleHealth.UnitHealthMax(target);
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /**  Get the estimated number of seconds remaining before the target is dead.
@@ -2209,7 +2208,7 @@ export class OvaleConditions {
                 return ReturnValueBetween(now, now + t, t, now, -1);
             }
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     /** Test if the given spell is in flight for spells that have a flight time after cast, e.g., Lava Burst.
@@ -2478,7 +2477,7 @@ export class OvaleConditions {
     ) => {
         const itemId = positionalParams[1];
         const value = GetItemCount(itemId, false, true);
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /** Get the current number of the given item in the player's inventory.
@@ -2498,7 +2497,7 @@ export class OvaleConditions {
     ) => {
         const itemId = positionalParams[1];
         const value = GetItemCount(itemId);
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /** Get the damage done by the most recent damage event for the given spell.
@@ -2521,7 +2520,7 @@ export class OvaleConditions {
         const spellId = positionalParams[1];
         const value = this.OvaleSpellDamage.Get(spellId);
         if (value) {
-            return Compare(value);
+            return ReturnConstant(value);
         }
         return [];
     };
@@ -2550,7 +2549,7 @@ export class OvaleConditions {
         } else {
             value = UnitLevel(target);
         }
-        return Compare(value);
+        return ReturnConstant(value);
     };
     /** Test if a list is currently set to the given value.
 	 @name List
@@ -2606,7 +2605,7 @@ export class OvaleConditions {
     ) => {
         const [version, , , uiVersion] = GetBuildInfo();
         const value = ((version > "9.0.2" || uiVersion > 90002) && 1) || 0;
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /** Get the persistent multiplier to the given aura if applied.
@@ -2641,7 +2640,7 @@ export class OvaleConditions {
             targetGuid,
             atTime
         );
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /** Test if the pet exists and is alive.
@@ -2690,7 +2689,7 @@ export class OvaleConditions {
                     UnitPowerMax(target, powerInfo.id, powerInfo.segments)) ||
                 0;
         }
-        return Compare(value);
+        return ReturnConstant(value);
     }
     /** Return the amount of power of the given power type on the target.
      */
@@ -2712,7 +2711,7 @@ export class OvaleConditions {
         } else {
             const powerInfo = this.OvalePower.POWER_INFO[powerType];
             const value = (powerInfo && UnitPower(target, powerInfo.id)) || 0;
-            return Compare(value);
+            return ReturnConstant(value);
         }
     }
     /**Return the current deficit of power from max power on the target.
@@ -2751,10 +2750,10 @@ export class OvaleConditions {
                 const power =
                     (powerInfo && UnitPower(target, powerInfo.id)) || 0;
                 const value = powerMax - power;
-                return Compare(value);
+                return ReturnConstant(value);
             }
         }
-        return Compare(0);
+        return ReturnConstant(0);
     }
 
     /**Return the current percent level of power (between 0 and 100) on the target.
@@ -2802,10 +2801,10 @@ export class OvaleConditions {
                 const ratio = 100 / powerMax;
                 const value =
                     (powerInfo && ratio * UnitPower(target, powerInfo.id)) || 0;
-                return Compare(value);
+                return ReturnConstant(value);
             }
         }
-        return Compare(0);
+        return ReturnConstant(0);
     }
 
     /**
@@ -3579,7 +3578,7 @@ l    */
                 target,
                 maxCost
             )) || [0];
-        return Compare(value);
+        return ReturnConstant(value);
     }
 
     /** Get the amount of energy required to cast the given spell.
@@ -3848,7 +3847,7 @@ l    */
         } else {
             value = level - this.OvalePaperDoll.level;
         }
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     private Refreshable = (
@@ -3934,7 +3933,7 @@ l    */
                 rate
             );
         }
-        return Compare(count);
+        return ReturnConstant(count);
     };
 
     private RuneDeficit = (
@@ -3955,7 +3954,7 @@ l    */
                 rate
             );
         }
-        return Compare(count);
+        return ReturnConstant(count);
     };
 
     /**  Get the current number of active runes of the given type for death knights.
@@ -3988,7 +3987,7 @@ l    */
                 0
             );
         }
-        return Compare(count);
+        return ReturnConstant(count);
     };
 
     /**  Get the number of seconds before the player reaches the given amount of runes.
@@ -4010,7 +4009,7 @@ l    */
         if (seconds < 0) {
             seconds = 0;
         }
-        return Compare(seconds);
+        return ReturnConstant(seconds);
     };
 
     /**  Returns the value of the given snapshot stat.
@@ -4024,7 +4023,7 @@ l    */
     ) {
         const value =
             this.OvalePaperDoll.GetState(atTime)[statName] || defaultValue;
-        return Compare(value);
+        return ReturnConstant(value);
     }
 
     /**  Returns the critical strike chance of the given snapshot stat.
@@ -4041,7 +4040,7 @@ l    */
         if (namedParams.unlimited != 1 && value > 100) {
             value = 100;
         }
-        return Compare(value);
+        return ReturnConstant(value);
     }
 
     /** Get the current agility of the player.
@@ -4404,7 +4403,7 @@ l    */
     ) => {
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const value = (GetUnitSpeed(target) * 100) / 7;
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /** Get the cooldown in seconds on a spell before it gains another charge.
@@ -4434,7 +4433,7 @@ l    */
             const ending = start + duration;
             return ReturnValueBetween(start, ending, duration, start, -1);
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     /** Get the number of charges of the spell.
@@ -4472,7 +4471,7 @@ l    */
                 1 / duration
             );
         }
-        return Compare(charges);
+        return ReturnConstant(charges);
     };
 
     /** Get the number of seconds for a full recharge of the spell.
@@ -4499,7 +4498,7 @@ l    */
             const ending = start + duration;
             return ReturnValueBetween(start, ending, duration, start, -1);
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     /** Get the number of seconds before any of the listed spells are ready for use.
@@ -4547,11 +4546,11 @@ l    */
             }
         }
         if (earliest == INFINITY) {
-            return Compare(0);
+            return ReturnConstant(0);
         } else if (earliest > 0) {
             return ReturnValue(0, earliest, -1);
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     /** Get the cooldown duration in seconds for a given spell.
@@ -4580,7 +4579,7 @@ l    */
             atTime,
             target
         );
-        return Compare(duration);
+        return ReturnConstant(duration);
     };
 
     /** Get the recharge duration in seconds for a given spell.
@@ -4612,7 +4611,7 @@ l    */
                 atTime,
                 target
             );
-        return Compare(duration);
+        return ReturnConstant(duration);
     };
 
     /** Get data for the given spell defined by SpellInfo(...)
@@ -4640,7 +4639,7 @@ l    */
         if (si) {
             const value = si[key];
             if (value) {
-                return Compare(<number>value);
+                return ReturnConstant(<number>value);
             }
         }
         return [];
@@ -4674,7 +4673,7 @@ l    */
             undefined
         );
         if (value) {
-            return Compare(<number>value);
+            return ReturnConstant(<number>value);
         }
         return [];
     };
@@ -4696,7 +4695,7 @@ l    */
     ) => {
         const spellId = positionalParams[1];
         const spellCount = this.OvaleSpells.GetSpellCount(spellId);
-        return Compare(spellCount);
+        return ReturnConstant(spellCount);
     };
 
     /** Test if the given spell is in the spellbook.
@@ -4745,7 +4744,7 @@ l    */
             return [];
         }
         maxCharges = maxCharges || 1;
-        return Compare(maxCharges);
+        return ReturnConstant(maxCharges);
     };
 
     /** Test if the given spell is usable.
@@ -4879,7 +4878,7 @@ l    */
     ) => {
         const talent = positionalParams[1];
         const value = this.OvaleSpellBook.GetTalentPoints(talent);
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /** Test if the player is the in-game target of the target.
@@ -4926,7 +4925,7 @@ l    */
             "target"
         );
         const [, , value] = UnitDetailedThreatSituation("player", target);
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /** Get the number of seconds between ticks of a periodic aura on a target.
@@ -4970,9 +4969,9 @@ l    */
             );
         }
         if (tickTime && tickTime > 0) {
-            return Compare(tickTime);
+            return ReturnConstant(tickTime);
         }
-        return Compare(INFINITY);
+        return ReturnConstant(INFINITY);
     };
 
     private CurrentTickTime = (
@@ -4998,7 +4997,7 @@ l    */
         } else {
             tickTime = 0;
         }
-        return Compare(tickTime);
+        return ReturnConstant(tickTime);
     };
 
     /** Get the remaining number of ticks of a periodic aura on a target.
@@ -5047,7 +5046,7 @@ l    */
                 );
             }
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     /** Gets the remaining time until the next tick */
@@ -5075,10 +5074,10 @@ l    */
                 this.OvaleAura.GetTickLength(auraId, this.OvalePaperDoll.next);
             const remainingTime = tick - (atTime - lastTickTime);
             if (remainingTime && remainingTime > 0) {
-                return Compare(remainingTime);
+                return ReturnConstant(remainingTime);
             }
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     /** Get the number of seconds elapsed since the player cast the given spell.
@@ -5115,7 +5114,7 @@ l    */
         atTime: number
     ) => {
         const value = 3600;
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     private TimeToEclipse = (
@@ -5139,12 +5138,12 @@ l    */
             atTime
         );
         if (seconds == 0) {
-            return Compare(0);
+            return ReturnConstant(0);
         } else if (seconds < INFINITY) {
             // XXX Why isn't this (atTime, atTime + seconds)?
             return ReturnValueBetween(0, atTime + seconds, seconds, atTime, -1);
         } else {
-            return Compare(INFINITY);
+            return ReturnConstant(INFINITY);
         }
     }
 
@@ -5255,12 +5254,12 @@ l    */
             powerType
         );
         if (seconds == 0) {
-            return Compare(0);
+            return ReturnConstant(0);
         } else if (seconds < INFINITY) {
             // XXX Why isn't this (atTime, atTime + seconds)?
             return ReturnValueBetween(0, atTime + seconds, seconds, atTime, -1);
         } else {
-            return Compare(INFINITY);
+            return ReturnConstant(INFINITY);
         }
     }
     /** Get the number of seconds before the player has enough energy to cast the given spell.
@@ -5327,11 +5326,11 @@ l    */
         let [target] = private ParseCondition = (positionalParams, namedParams, "target");
         let seconds = OvaleSpells.GetTimeToSpell(spellId, atTime, OvaleGUID.UnitGUID(target));
         if (seconds == 0) {
-            return Compare(0);
+            return ReturnConstant(0);
         } else if (seconds < INFINITY) {
             return ReturnValueBetween(0, atTime + seconds, seconds, atTime, -1);
         } else {
-            return Compare(INFINITY);
+            return ReturnConstant(INFINITY);
         }
         */
         OneTimeMessage("Warning: 'TimeToSpell()' is not implemented.");
@@ -5359,7 +5358,7 @@ l    */
         const seconds = positionalParams[1];
         const haste = (namedParams.haste as HasteType) || "spell";
         const value = this.GetHastedTime(seconds, haste);
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /** Test if the totem has expired.
@@ -5442,7 +5441,7 @@ l    */
         ) {
             return ReturnValueBetween(start, ending, 0, ending, -1);
         }
-        return Compare(0);
+        return ReturnConstant(0);
     };
 
     /** Check if a tracking is enabled
@@ -5499,7 +5498,7 @@ l    */
                 travelTime = estimatedTravelTime;
             }
         }
-        return Compare(travelTime);
+        return ReturnConstant(travelTime);
     };
 
     /**  A condition that always returns true.
@@ -5542,7 +5541,7 @@ l    */
         } else {
             value = this.OvalePaperDoll.current.mainHandWeaponDPS || 0;
         }
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /** Test if a sigil is charging
@@ -5650,7 +5649,7 @@ l    */
         atTime: number
     ) => {
         const value = this.OvaleDemonHunterSoulFragments.SoulFragments(atTime);
-        return Compare(value);
+        return ReturnConstant(value);
     };
 
     /** Test if a specific dispel type is present.

--- a/src/states/conditions.ts
+++ b/src/states/conditions.ts
@@ -191,8 +191,6 @@ export class OvaleConditions {
 	@return A boolean value for the result of the comparison.
 	@usage
 	if ArmorSetParts(T13) >=2 and target.HealthPercent() <60
-	    Spell(ferocious_bite)
-	if ArmorSetParts(T13 more 1) and target.HealthPercent(less 60)
 	    Spell(ferocious_bite) */
     private ArmorSetParts = (
         positionalParams: LuaArray<any>,
@@ -1701,7 +1699,7 @@ export class OvaleConditions {
 	 @return The distance to the target.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if target.Distance(less 25)
+	 if target.Distance() < 25
 	     Texture(ability_rogue_sprint)
      */
     private Distance = (
@@ -1724,8 +1722,7 @@ export class OvaleConditions {
 	 @return The number of enemies.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if Enemies() >4 Spell(fan_of_knives)
-	 if Enemies(more 4) Spell(fan_of_knives)
+	 if Enemies() > 4 Spell(fan_of_knives)
      */
     private Enemies = (
         positionalParams: LuaArray<any>,
@@ -1843,8 +1840,7 @@ export class OvaleConditions {
 	 @return The current rate of focus regeneration.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if FocusRegenRate() >20 Spell(arcane_shot)
-	 if FocusRegenRate(more 20) Spell(arcane_shot)
+	 if FocusRegenRate() > 20 Spell(arcane_shot)
      */
     private FocusRegenRate = (
         positionalParams: LuaArray<any>,
@@ -1907,8 +1903,7 @@ export class OvaleConditions {
 	 @return The number of seconds.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if GCD() <1.1 Spell(frostfire_bolt)
-	 if GCD(less 1.1) Spell(frostfire_bolt)
+	 if GCD() < 1.1 Spell(frostfire_bolt)
      */
     private GCD = (
         positionalParams: LuaArray<any>,
@@ -1990,8 +1985,7 @@ export class OvaleConditions {
 	 @return A boolean value for the result of the comparison.
 	 @see Life
 	 @usage
-	 if Health() <10000 Spell(last_stand)
-	 if Health(less 10000) Spell(last_stand)
+	 if Health() < 10000 Spell(last_stand)
      */
     private Health = (
         positionalParams: LuaArray<any>,
@@ -2019,8 +2013,7 @@ export class OvaleConditions {
 	 @return A boolean value for the result of the comparison.
 	 @see Life
 	 @usage
-	 if EffectiveHealth() <10000 Spell(last_stand)
-	 if EffectiveHealth(less 10000) Spell(last_stand)
+	 if EffectiveHealth() < 10000 Spell(last_stand)
      */
     private EffectiveHealth = (
         positionalParams: LuaArray<any>,
@@ -2049,8 +2042,7 @@ export class OvaleConditions {
 	 @return A boolean value for the result of the comparison.
 	 @see LifeMissing
 	 @usage
-	 if HealthMissing() <20000 Item(healthstone)
-	 if HealthMissing(less 20000) Item(healthstone)
+	 if HealthMissing() < 20000 Item(healthstone)
      */
     private HealthMissing = (
         positionalParams: LuaArray<any>,
@@ -2080,8 +2072,8 @@ export class OvaleConditions {
 	 @return A boolean value for the result of the comparison.
 	 @see LifePercent
 	 @usage
-	 if HealthPercent() <20 Spell(last_stand)
-	 if target.HealthPercent(less 25) Spell(kill_shot)
+	 if HealthPercent() < 20 Spell(last_stand)
+	 if target.HealthPercent() < 25 Spell(kill_shot)
      */
     private HealthPercent = (
         positionalParams: LuaArray<any>,
@@ -2110,8 +2102,8 @@ export class OvaleConditions {
 	 @return The current health percent including absorbs.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if EffectiveHealthPercent() <20 Spell(last_stand)
-	 if target.EffectiveHealthPercent(less 25) Spell(kill_shot)
+	 if EffectiveHealthPercent() < 20 Spell(last_stand)
+	 if target.EffectiveHealthPercent() < 25 Spell(kill_shot)
      */
     private EffectiveHealthPercent = (
         positionalParams: LuaArray<any>,
@@ -2141,8 +2133,7 @@ export class OvaleConditions {
 	 @return The maximum health.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if target.MaxHealth() >10000000 Item(mogu_power_potion)
-	 if target.MaxHealth(more 10000000) Item(mogu_power_potion)
+	 if target.MaxHealth() > 10000000 Item(mogu_power_potion)
      */
     private MaxHealth = (
         positionalParams: LuaArray<any>,
@@ -2467,8 +2458,6 @@ export class OvaleConditions {
 	 @usage
 	 if ItemCount(mana_gem) ==0 or ItemCharges(mana_gem) <3
 	     Spell(conjure_mana_gem)
-	 if ItemCount(mana_gem equal 0) or ItemCharges(mana_gem less 3)
-	     Spell(conjure_mana_gem)
      */
     private ItemCharges = (
         positionalParams: LuaArray<any>,
@@ -2487,8 +2476,7 @@ export class OvaleConditions {
 	 @return The count of the item.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if ItemCount(mana_gem) ==0 Spell(conjure_mana_gem)
-	 if ItemCount(mana_gem equal 0) Spell(conjure_mana_gem)
+	 if ItemCount(mana_gem) == 0 Spell(conjure_mana_gem)
      */
     private ItemCount = (
         positionalParams: LuaArray<any>,
@@ -2509,8 +2497,7 @@ export class OvaleConditions {
 	 @return A boolean value for the result of the comparison.
 	 @see Damage, LastEstimatedDamage
 	 @usage
-	 if LastDamage(ignite) >10000 Spell(combustion)
-	 if LastDamage(ignite more 10000) Spell(combustion)
+	 if LastDamage(ignite) > 10000 Spell(combustion)
      */
     private LastDamage = (
         positionalParams: LuaArray<any>,
@@ -2534,8 +2521,7 @@ export class OvaleConditions {
 	 @return The level of the target.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if Level() >=34 Spell(tiger_palm)
-	 if Level(more 33) Spell(tiger_palm)
+	 if Level() >= 34 Spell(tiger_palm)
      */
     private Level = (
         positionalParams: LuaArray<any>,
@@ -2827,8 +2813,7 @@ export class OvaleConditions {
 	 @return The current runic power.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if AstraPower() >70 Spell(frost_strike)
-	 if AstraPower(more 70) Spell(frost_strike)
+	 if AstraPower() > 70 Spell(frost_strike)
      */
     private AstralPower = (
         positionalParams: LuaArray<any>,
@@ -2844,8 +2829,7 @@ export class OvaleConditions {
 	 @return The amount of stored Chi.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if Chi() ==4 Spell(chi_burst)
-	 if Chi(more 3) Spell(chi_burst)
+	 if Chi() == 4 Spell(chi_burst)
      */
     private Chi = (
         positionalParams: LuaArray<any>,
@@ -2875,8 +2859,7 @@ export class OvaleConditions {
 	 @return The current energy.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if Energy() >70 Spell(vanish)
-	 if Energy(more 70) Spell(vanish)
+	 if Energy() > 70 Spell(vanish)
      */
     private Energy = (
         positionalParams: LuaArray<any>,
@@ -2892,8 +2875,7 @@ export class OvaleConditions {
 	 @return The current focus.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if Focus() >70 Spell(arcane_shot)
-	 if Focus(more 70) Spell(arcane_shot)
+	 if Focus() > 70 Spell(arcane_shot)
      */
     private Focus = (
         positionalParams: LuaArray<any>,
@@ -2924,8 +2906,7 @@ export class OvaleConditions {
 	 @return The amount of holy power.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if HolyPower() >=3 Spell(word_of_glory)
-	 if HolyPower(more 2) Spell(word_of_glory)
+	 if HolyPower() >= 3 Spell(word_of_glory)
      */
     private HolyPower = (
         positionalParams: LuaArray<any>,
@@ -3005,8 +2986,7 @@ export class OvaleConditions {
 	 @return The current rage.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if Rage() >70 Spell(heroic_strike)
-	 if Rage(more 70) Spell(heroic_strike)
+	 if Rage() > 70 Spell(heroic_strike)
      */
     private Rage = (
         positionalParams: LuaArray<any>,
@@ -3022,8 +3002,7 @@ export class OvaleConditions {
 	 @return The current runic power.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if RunicPower() >70 Spell(frost_strike)
-	 if RunicPower(more 70) Spell(frost_strike)
+	 if RunicPower() > 70 Spell(frost_strike)
      */
     private RunicPower = (
         positionalParams: LuaArray<any>,
@@ -3039,8 +3018,7 @@ export class OvaleConditions {
 	 @return The number of Soul Shards.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if SoulShards() >0 Spell(summon_felhunter)
-	 if SoulShards(more 0) Spell(summon_felhunter)
+	 if SoulShards() > 0 Spell(summon_felhunter)
      */
     private SoulShards = (
         positionalParams: LuaArray<any>,
@@ -3115,8 +3093,7 @@ export class OvaleConditions {
 	 @return The current chi deficit.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if ChiDeficit() >=2 Spell(keg_smash)
-	 if ChiDeficit(more 1) Spell(keg_smash)
+	 if ChiDeficit() >= 2 Spell(keg_smash)
      */
     private ChiDeficit = (
         positionalParams: LuaArray<any>,
@@ -3154,8 +3131,7 @@ export class OvaleConditions {
 	 @return The current energy deficit.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if EnergyDeficit() >60 Spell(tigers_fury)
-	 if EnergyDeficit(more 60) Spell(tigers_fury)
+	 if EnergyDeficit() > 60 Spell(tigers_fury)
      */
     private EnergyDeficit = (
         positionalParams: LuaArray<any>,
@@ -3230,8 +3206,7 @@ export class OvaleConditions {
 	 @return The current mana deficit.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if ManaDeficit() >30000 Item(mana_gem)
-	 if ManaDeficit(more 30000) Item(mana_gem)
+	 if ManaDeficit() > 30000 Item(mana_gem)
      */
     private ManaDeficit = (
         positionalParams: LuaArray<any>,
@@ -3318,8 +3293,7 @@ export class OvaleConditions {
 	 @return The current mana percent.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if ManaPercent() >90 Spell(arcane_blast)
-	 if ManaPercent(more 90) Spell(arcane_blast)
+	 if ManaPercent() > 90 Spell(arcane_blast)
      */
     private ManaPercent = (
         positionalParams: LuaArray<any>,
@@ -3825,9 +3799,7 @@ l    */
 	 @return The difference in levels.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if target.RelativeLevel() >3
-	     Texture(ability_rogue_sprint)
-	 if target.RelativeLevel(more 3)
+	 if target.RelativeLevel() > 3
 	     Texture(ability_rogue_sprint)
      */
     private RelativeLevel = (
@@ -4393,7 +4365,7 @@ l    */
 	 @return The speed of the target.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if Speed(more 0) and not BuffPresent(aspect_of_the_fox)
+	 if Speed() > 0 and not BuffPresent(aspect_of_the_fox)
 	     Spell(aspect_of_the_fox)
      */
     private Speed = (
@@ -4911,8 +4883,7 @@ l    */
 	 @return The amount of threat.
 	 @return A boolean value for the result of the comparison.
 	 @usage
-	 if Threat() >90 Spell(fade)
-	 if Threat(more 90) Spell(fade)
+	 if Threat() > 90 Spell(fade)
      */
     private Threat = (
         positionalParams: LuaArray<any>,

--- a/src/states/conditions.ts
+++ b/src/states/conditions.ts
@@ -1,17 +1,16 @@
 import LibBabbleCreatureType from "@wowts/lib_babble-creature_type-3.0";
 import LibRangeCheck from "@wowts/lib_range_check-2.0";
 import {
-    TestValue,
     Compare,
     ConditionFunction,
-    ReturnValue,
-    OvaleConditionClass,
-    ReturnConstant,
     ConditionResult,
+    OvaleConditionClass,
     ParseCondition,
-    ReturnValueBetween,
     ParameterInfo,
     ReturnBoolean,
+    ReturnConstant,
+    ReturnValue,
+    ReturnValueBetween,
 } from "../engine/condition";
 import { SpellInfo, OvaleDataClass, SpellInfoProperty } from "../engine/data";
 import { PowerType, OvalePowerClass } from "./Power";
@@ -328,9 +327,14 @@ export class OvaleConditions {
             mine
         );
         if (aura && this.OvaleAura.IsActiveAura(aura, atTime)) {
-            const [gain, start, ending] = [aura.gain, aura.start, aura.ending];
             const value = aura[statName] || 0;
-            return TestValue(gain, ending, value, start, 0);
+            return ReturnValueBetween(
+                aura.gain,
+                aura.ending,
+                value,
+                aura.start,
+                0
+            );
         }
         return Compare(0);
     };
@@ -365,9 +369,14 @@ export class OvaleConditions {
             mine
         );
         if (aura && this.OvaleAura.IsActiveAura(aura, atTime)) {
-            const [gain, start, ending] = [aura.gain, aura.start, aura.ending];
             const value = (aura && aura.combopoints) || 0;
-            return TestValue(gain, ending, value, start, 0);
+            return ReturnValueBetween(
+                aura.gain,
+                aura.ending,
+                value,
+                aura.start,
+                0
+            );
         }
         return Compare(0);
     };
@@ -526,10 +535,14 @@ export class OvaleConditions {
             excludeUnitId
         );
         if (count > 0 && startChangeCount < INFINITY && fractional) {
-            const origin = startChangeCount;
             const rate = -1 / (endingChangeCount - startChangeCount);
-            const [start, ending] = [startFirst, endingLast];
-            return TestValue(start, ending, count, origin, rate);
+            return ReturnValueBetween(
+                startFirst,
+                endingLast,
+                count,
+                startChangeCount,
+                rate
+            );
         }
         return Compare(count);
     };
@@ -568,13 +581,13 @@ export class OvaleConditions {
             mine
         );
         if (aura) {
-            const [gain, , , direction] = [
+            return ReturnValueBetween(
                 aura.gain,
-                aura.start,
-                aura.ending,
+                INFINITY,
                 aura.direction,
-            ];
-            return TestValue(gain, INFINITY, direction, gain, 0);
+                aura.gain,
+                0
+            );
         }
         return Compare(0);
     };
@@ -608,9 +621,14 @@ export class OvaleConditions {
             mine
         );
         if (aura && this.OvaleAura.IsActiveAura(aura, atTime)) {
-            const [gain, start, ending] = [aura.gain, aura.start, aura.ending];
-            const value = ending - start;
-            return TestValue(gain, ending, value, start, 0);
+            const duration = aura.ending - aura.start;
+            return ReturnValueBetween(
+                aura.gain,
+                aura.ending,
+                duration,
+                aura.start,
+                0
+            );
         }
         return Compare(0);
     };
@@ -756,7 +774,7 @@ export class OvaleConditions {
         );
         if (aura) {
             const gain = aura.gain || 0;
-            return TestValue(gain, INFINITY, 0, gain, 1);
+            return ReturnValueBetween(gain, INFINITY, 0, gain, 1);
         }
         return Compare(0);
     };
@@ -803,9 +821,14 @@ export class OvaleConditions {
             mine
         );
         if (aura && this.OvaleAura.IsActiveAura(aura, atTime)) {
-            const [gain, start, ending] = [aura.gain, aura.start, aura.ending];
             const value = aura.damageMultiplier || 1;
-            return TestValue(gain, ending, value, start, 0);
+            return ReturnValueBetween(
+                aura.gain,
+                aura.ending,
+                value,
+                aura.start,
+                0
+            );
         }
         return Compare(1);
     };
@@ -845,8 +868,7 @@ export class OvaleConditions {
             mine
         );
         if (aura && aura.ending >= atTime) {
-            const [gain, , ending] = [aura.gain, aura.start, aura.ending];
-            return TestValue(gain, INFINITY, 0, ending, -1);
+            return ReturnValueBetween(aura.gain, INFINITY, 0, aura.ending, -1);
         }
         return Compare(0);
     };
@@ -890,8 +912,7 @@ export class OvaleConditions {
             excludeUnitId
         );
         if (count > 0) {
-            const [start, ending] = [startFirst, endingLast];
-            return TestValue(start, INFINITY, 0, ending, -1);
+            return ReturnValueBetween(startFirst, INFINITY, 0, endingLast, -1);
         }
         return Compare(0);
     };
@@ -933,9 +954,14 @@ export class OvaleConditions {
             mine
         );
         if (aura && this.OvaleAura.IsActiveAura(aura, atTime)) {
-            const [gain, start, ending] = [aura.gain, aura.start, aura.ending];
             const value = aura.stacks || 0;
-            return TestValue(gain, ending, value, start, 0);
+            return ReturnValueBetween(
+                aura.gain,
+                aura.ending,
+                value,
+                aura.start,
+                0
+            );
         }
         return Compare(0);
     };
@@ -993,8 +1019,13 @@ export class OvaleConditions {
             excludeUnitId
         );
         if (count > 0) {
-            const [start, ending] = [startFirst, endingChangeCount];
-            return TestValue(start, ending, stacks, start, 0);
+            return ReturnValueBetween(
+                startFirst,
+                endingChangeCount,
+                stacks,
+                startFirst,
+                0
+            );
         }
         return Compare(count);
     };
@@ -1595,8 +1626,7 @@ export class OvaleConditions {
             aura = (bpAura.ending < ffAura.ending && bpAura) || ffAura;
         }
         if (aura) {
-            const [gain, , ending] = [aura.gain, aura.start, aura.ending];
-            return TestValue(gain, INFINITY, 0, ending, -1);
+            return ReturnValueBetween(aura.gain, INFINITY, 0, aura.ending, -1);
         }
         return Compare(0);
     };
@@ -1769,8 +1799,7 @@ export class OvaleConditions {
             false
         );
         if (aura && aura.ending >= atTime) {
-            const [gain, , ending] = [aura.gain, aura.start, aura.ending];
-            return TestValue(gain, INFINITY, 0, ending, -1);
+            return ReturnValueBetween(aura.gain, INFINITY, 0, aura.ending, -1);
         }
         return Compare(0);
     };
@@ -1922,7 +1951,7 @@ export class OvaleConditions {
             const start = (spellcast && spellcast.start) || 0;
             const ending = start + duration;
             if (atTime < ending) {
-                return TestValue(start, INFINITY, 0, ending, -1);
+                return ReturnValueBetween(start, INFINITY, 0, ending, -1);
             }
         }
         return Compare(0);
@@ -1975,13 +2004,8 @@ export class OvaleConditions {
         if (health > 0) {
             const now = this.baseState.currentTime;
             const timeToDie = this.OvaleHealth.UnitTimeToDie(target);
-            const [value, origin, rate] = [
-                health,
-                now,
-                (-1 * health) / timeToDie,
-            ];
-            const [start, ending] = [now, INFINITY];
-            return TestValue(start, ending, value, origin, rate);
+            const rate = (-1 * health) / timeToDie;
+            return ReturnValueBetween(now, INFINITY, health, now, rate);
         }
         return Compare(0);
     };
@@ -2012,9 +2036,8 @@ export class OvaleConditions {
 
         const now = this.baseState.currentTime;
         const timeToDie = this.OvaleHealth.UnitTimeToDie(target);
-        const [value, origin, rate] = [health, now, (-1 * health) / timeToDie];
-        const [start, ending] = [now, INFINITY];
-        return TestValue(start, ending, value, origin, rate);
+        const rate = (-1 * health) / timeToDie;
+        return ReturnValueBetween(now, INFINITY, health, now, rate);
     };
 
     /** Get the number of health points away from full health of the target.
@@ -2042,9 +2065,8 @@ export class OvaleConditions {
             const now = this.baseState.currentTime;
             const missing = maxHealth - health;
             const timeToDie = this.OvaleHealth.UnitTimeToDie(target);
-            const [value, origin, rate] = [missing, now, health / timeToDie];
-            const [start, ending] = [now, INFINITY];
-            return TestValue(start, ending, value, origin, rate);
+            const rate = health / timeToDie;
+            return ReturnValueBetween(now, INFINITY, missing, now, rate);
         }
         return Compare(maxHealth);
     };
@@ -2072,15 +2094,10 @@ export class OvaleConditions {
         if (health > 0) {
             const now = this.baseState.currentTime;
             const maxHealth = this.OvaleHealth.UnitHealthMax(target) || 1;
-            const healthPercent = (health / maxHealth) * 100;
+            const healthPct = (health / maxHealth) * 100;
             const timeToDie = this.OvaleHealth.UnitTimeToDie(target);
-            const [value, origin, rate] = [
-                healthPercent,
-                now,
-                (-1 * healthPercent) / timeToDie,
-            ];
-            const [start, ending] = [now, INFINITY];
-            return TestValue(start, ending, value, origin, rate);
+            const rate = (-1 * healthPct) / timeToDie;
+            return ReturnValueBetween(now, INFINITY, healthPct, now, rate);
         }
         return Compare(0);
     };
@@ -2110,15 +2127,10 @@ export class OvaleConditions {
 
         const now = this.baseState.currentTime;
         const maxHealth = this.OvaleHealth.UnitHealthMax(target) || 1;
-        const healthPercent = (health / maxHealth) * 100;
+        const healthPct = (health / maxHealth) * 100;
         const timeToDie = this.OvaleHealth.UnitTimeToDie(target);
-        const [value, origin, rate] = [
-            healthPercent,
-            now,
-            (-1 * healthPercent) / timeToDie,
-        ];
-        const [start, ending] = [now, INFINITY];
-        return TestValue(start, ending, value, origin, rate);
+        const rate = (-1 * healthPct) / timeToDie;
+        return ReturnValueBetween(now, INFINITY, healthPct, now, rate);
     };
 
     /** Get the amount of health points of the target when it is at full health.
@@ -2163,9 +2175,7 @@ export class OvaleConditions {
         const [target] = this.ParseCondition(positionalParams, namedParams);
         const now = this.baseState.currentTime;
         const timeToDie = this.OvaleHealth.UnitTimeToDie(target);
-        const [value, origin, rate] = [timeToDie, now, -1];
-        const [start] = [now, now + timeToDie];
-        return TestValue(start, INFINITY, value, origin, rate);
+        return ReturnValueBetween(now, INFINITY, timeToDie, now, -1);
     };
 
     /** Get the estimated number of seconds remaining before the target reaches the given percent of max health.
@@ -2191,15 +2201,12 @@ export class OvaleConditions {
         const health = this.OvaleHealth.UnitHealth(target) || 0;
         if (health > 0) {
             const maxHealth = this.OvaleHealth.UnitHealthMax(target) || 1;
-            const healthPercent = (health / maxHealth) * 100;
-            if (healthPercent >= percent) {
+            const healthPct = (health / maxHealth) * 100;
+            if (healthPct >= percent) {
                 const now = this.baseState.currentTime;
                 const timeToDie = this.OvaleHealth.UnitTimeToDie(target);
-                const t =
-                    (timeToDie * (healthPercent - percent)) / healthPercent;
-                const [value, origin, rate] = [t, now, -1];
-                const [start, ending] = [now, now + t];
-                return TestValue(start, ending, value, origin, rate);
+                const t = (timeToDie * (healthPct - percent)) / healthPct;
+                return ReturnValueBetween(now, now + t, t, now, -1);
             }
         }
         return Compare(0);
@@ -2695,17 +2702,13 @@ export class OvaleConditions {
     ) {
         const [target] = this.ParseCondition(positionalParams, namedParams);
         if (target == "player") {
-            const [value, origin, rate] = [
-                this.OvalePower.next.power[powerType],
-                atTime,
-                this.OvalePower.getPowerRateAt(
-                    this.OvalePower.next,
-                    powerType,
-                    atTime
-                ),
-            ];
-            const [start, ending] = [atTime, INFINITY];
-            return TestValue(start, ending, value, origin, rate);
+            const value = this.OvalePower.next.power[powerType] || 0;
+            const rate = this.OvalePower.getPowerRateAt(
+                this.OvalePower.next,
+                powerType,
+                atTime
+            );
+            return ReturnValueBetween(atTime, INFINITY, value, atTime, rate);
         } else {
             const powerInfo = this.OvalePower.POWER_INFO[powerType];
             const value = (powerInfo && UnitPower(target, powerInfo.id)) || 0;
@@ -2725,18 +2728,18 @@ export class OvaleConditions {
             const powerMax = this.OvalePower.current.maxPower[powerType] || 0;
             if (powerMax > 0) {
                 const power = this.OvalePower.next.power[powerType] || 0;
-                const [value, origin, rate] = [
+                const rate = this.OvalePower.getPowerRateAt(
+                    this.OvalePower.next,
+                    powerType,
+                    atTime
+                );
+                return ReturnValueBetween(
+                    atTime,
+                    INFINITY,
                     powerMax - power,
                     atTime,
-                    -1 *
-                        this.OvalePower.getPowerRateAt(
-                            this.OvalePower.next,
-                            powerType,
-                            atTime
-                        ),
-                ];
-                const [start, ending] = [atTime, INFINITY];
-                return TestValue(start, ending, value, origin, rate);
+                    -1 * rate
+                );
             }
         } else {
             const powerInfo = this.OvalePower.POWER_INFO[powerType];
@@ -2766,21 +2769,28 @@ export class OvaleConditions {
         if (target == "player") {
             const powerMax = this.OvalePower.current.maxPower[powerType] || 0;
             if (powerMax > 0) {
-                const conversion = 100 / powerMax;
+                const ratio = 100 / powerMax;
                 const power = this.OvalePower.next.power[powerType] || 0;
-                const value = power * conversion;
-                const origin = atTime;
                 let rate =
+                    ratio *
                     this.OvalePower.getPowerRateAt(
                         this.OvalePower.next,
                         powerType,
                         atTime
-                    ) * conversion;
-                if ((rate > 0 && value >= 100) || (rate < 0 && value == 0)) {
+                    );
+                if (
+                    (rate > 0 && power >= powerMax) ||
+                    (rate < 0 && power == 0)
+                ) {
                     rate = 0;
                 }
-                const [start, ending] = [atTime, INFINITY];
-                return TestValue(start, ending, value, origin, rate);
+                return ReturnValueBetween(
+                    atTime,
+                    INFINITY,
+                    power * ratio,
+                    atTime,
+                    rate
+                );
             }
         } else {
             const powerInfo = this.OvalePower.POWER_INFO[powerType];
@@ -2789,11 +2799,9 @@ export class OvaleConditions {
                     UnitPowerMax(target, powerInfo.id, powerInfo.segments)) ||
                 0;
             if (powerMax > 0) {
-                const conversion = 100 / powerMax;
+                const ratio = 100 / powerMax;
                 const value =
-                    (powerInfo &&
-                        UnitPower(target, powerInfo.id) * conversion) ||
-                    0;
+                    (powerInfo && ratio * UnitPower(target, powerInfo.id)) || 0;
                 return Compare(value);
             }
         }
@@ -3894,7 +3902,7 @@ l    */
         if (startTime && endTime) {
             startTime = startTime / 1000;
             endTime = endTime / 1000;
-            return TestValue(startTime, endTime, 0, endTime, -1);
+            return ReturnValueBetween(startTime, endTime, 0, endTime, -1);
         }
         return [];
     };
@@ -3917,10 +3925,14 @@ l    */
             atTime
         );
         if (startCooldown < INFINITY) {
-            const origin = startCooldown;
             const rate = 1 / (endCooldown - startCooldown);
-            const [start, ending] = [startCooldown, INFINITY];
-            return TestValue(start, ending, count, origin, rate);
+            return ReturnValueBetween(
+                startCooldown,
+                INFINITY,
+                count,
+                startCooldown,
+                rate
+            );
         }
         return Compare(count);
     };
@@ -3934,10 +3946,14 @@ l    */
             atTime
         );
         if (startCooldown < INFINITY) {
-            const origin = startCooldown;
             const rate = -1 / (endCooldown - startCooldown);
-            const [start, ending] = [startCooldown, INFINITY];
-            return TestValue(start, ending, count, origin, rate);
+            return ReturnValueBetween(
+                startCooldown,
+                INFINITY,
+                count,
+                startCooldown,
+                rate
+            );
         }
         return Compare(count);
     };
@@ -3964,8 +3980,13 @@ l    */
             atTime
         );
         if (startCooldown < INFINITY) {
-            const [start, ending] = [startCooldown, endCooldown];
-            return TestValue(start, ending, count, start, 0);
+            return ReturnValueBetween(
+                startCooldown,
+                endCooldown,
+                count,
+                startCooldown,
+                0
+            );
         }
         return Compare(count);
     };
@@ -4411,7 +4432,7 @@ l    */
         ] = this.OvaleCooldown.GetSpellCharges(spellId, atTime);
         if (charges && charges < maxCharges) {
             const ending = start + duration;
-            return TestValue(start, ending, duration, start, -1);
+            return ReturnValueBetween(start, ending, duration, start, -1);
         }
         return Compare(0);
     };
@@ -4443,7 +4464,7 @@ l    */
             duration,
         ] = this.OvaleCooldown.GetSpellCharges(spellId, atTime);
         if (namedParams.count == 0 && charges < maxCharges) {
-            return TestValue(
+            return ReturnValueBetween(
                 atTime,
                 INFINITY,
                 charges + 1,
@@ -4471,12 +4492,12 @@ l    */
             charges,
             maxCharges,
             start,
-            dur,
+            chargeDuration,
         ] = this.OvaleCooldown.GetSpellCharges(spellId, atTime);
         if (charges && charges < maxCharges) {
-            const duration = (maxCharges - charges) * dur;
+            const duration = (maxCharges - charges) * chargeDuration;
             const ending = start + duration;
-            return TestValue(start, ending, duration, start, -1);
+            return ReturnValueBetween(start, ending, duration, start, -1);
         }
         return Compare(0);
     };
@@ -4528,7 +4549,7 @@ l    */
         if (earliest == INFINITY) {
             return Compare(0);
         } else if (earliest > 0) {
-            return TestValue(0, INFINITY, 0, earliest, -1);
+            return ReturnValue(0, earliest, -1);
         }
         return Compare(0);
     };
@@ -4800,7 +4821,7 @@ l    */
         //const swing = positionalParams[1];
         const start = 0;
         OneTimeMessage("Warning: 'LastSwing()' is not implemented.");
-        return TestValue(start, INFINITY, 0, start, 1);
+        return ReturnValueBetween(start, INFINITY, 0, start, 1);
     };
 
     /** Get the time in seconds until the player's next melee swing (white attack).
@@ -4821,7 +4842,7 @@ l    */
         //const swing = positionalParams[1];
         const ending = 0;
         OneTimeMessage("Warning: 'NextSwing()' is not implemented.");
-        return TestValue(0, ending, 0, ending, -1);
+        return ReturnValueBetween(0, ending, 0, ending, -1);
     };
 
     /** Test if the given talent is active.
@@ -5015,14 +5036,15 @@ l    */
             mine
         );
         if (aura) {
-            const [gain, , ending, tick] = [
-                aura.gain,
-                aura.start,
-                aura.ending,
-                aura.tick,
-            ];
+            const tick = aura.tick;
             if (tick && tick > 0) {
-                return TestValue(gain, INFINITY, 1, ending, -1 / tick);
+                return ReturnValueBetween(
+                    aura.gain,
+                    INFINITY,
+                    1,
+                    aura.ending,
+                    -1 / tick
+                );
             }
         }
         return Compare(0);
@@ -5077,7 +5099,7 @@ l    */
         const spellId = this.OvaleSpellBook.getKnownSpellId(spell);
         if (!spellId) return [];
         const t = this.OvaleFuture.TimeOfLastCast(spellId, atTime);
-        return TestValue(0, INFINITY, 0, t, 1);
+        return ReturnValue(0, t, 1);
     };
 
     /** Get the time in seconds until the next scheduled Bloodlust cast.
@@ -5103,7 +5125,7 @@ l    */
     ) => {
         const value = 3600 * 24 * 7;
         OneTimeMessage("Warning: 'TimeToEclipse()' is not implemented.");
-        return TestValue(0, INFINITY, value, atTime, -1);
+        return ReturnValue(value, atTime, -1);
     };
 
     /** Get the number of seconds before the player reaches the given power level.
@@ -5119,7 +5141,8 @@ l    */
         if (seconds == 0) {
             return Compare(0);
         } else if (seconds < INFINITY) {
-            return TestValue(0, atTime + seconds, seconds, atTime, -1);
+            // XXX Why isn't this (atTime, atTime + seconds)?
+            return ReturnValueBetween(0, atTime + seconds, seconds, atTime, -1);
         } else {
             return Compare(INFINITY);
         }
@@ -5234,7 +5257,8 @@ l    */
         if (seconds == 0) {
             return Compare(0);
         } else if (seconds < INFINITY) {
-            return TestValue(0, atTime + seconds, seconds, atTime, -1);
+            // XXX Why isn't this (atTime, atTime + seconds)?
+            return ReturnValueBetween(0, atTime + seconds, seconds, atTime, -1);
         } else {
             return Compare(INFINITY);
         }
@@ -5305,13 +5329,13 @@ l    */
         if (seconds == 0) {
             return Compare(0);
         } else if (seconds < INFINITY) {
-            return TestValue(0, atTime + seconds, seconds, atTime, -1);
+            return ReturnValueBetween(0, atTime + seconds, seconds, atTime, -1);
         } else {
             return Compare(INFINITY);
         }
         */
         OneTimeMessage("Warning: 'TimeToSpell()' is not implemented.");
-        return TestValue(0, INFINITY, 0, atTime, -1);
+        return ReturnValue(0, atTime, -1);
     };
     /** Get the time scaled by the specified haste type, defaulting to spell haste.
 	 For example, if a DoT normally ticks every 3 seconds and is scaled by spell haste, then it ticks every TimeWithHaste(3 haste=spell) seconds.
@@ -5416,7 +5440,7 @@ l    */
             ending !== undefined &&
             count > 0
         ) {
-            return TestValue(start, ending, 0, ending, -1);
+            return ReturnValueBetween(start, ending, 0, ending, -1);
         }
         return Compare(0);
     };


### PR DESCRIPTION
This pullup does three things:
* Modifies `engine/condition.ts` and the state modules to stop accepting "comparator-limit" parameters, e.g., `ValueCondition(less 5)` instead of `ValueCondition() < 5`, and "yesno" parameters, e.g., `BooleanCondition(no)` instead of `not BooleanCondition()`. 
* Cleans up the usage of `TestValue()` and `Compare()`, replacing them with `ReturnValue()` and `ReturnConstant()`.
* Fixes `simulationcraft` modules to stop using "comparator-limit" parameters in the warrior script.