### PR TITLE
Fix script translations of totem pets

### DIFF
--- a/src/simulationcraft/emiter.ts
+++ b/src/simulationcraft/emiter.ts
@@ -87,7 +87,7 @@ function IsTotem(name: string) {
         return true;
     } else if (sub(name, -7, -1) == "_statue") {
         return true;
-    } else if (truthy(match(name, "invoke_(niuzao|xuen|chiji)"))) {
+    } else if (truthy(match(name, "invoke_(chiji|yulon)"))) {
         return true;
     } else if (sub(name, -6, -1) == "_totem") {
         return true;
@@ -270,6 +270,18 @@ export class Emiter {
             "energizing_elixir_talent",
             "MONK",
             "windwalker"
+        );
+        this.AddDisambiguation(
+            "chiji_the_red_crane",
+            "invoke_chiji_the_red_crane",
+            "MONK",
+            "mistweaver"
+        );
+        this.AddDisambiguation(
+            "yulon_the_jade_serpent",
+            "invoke_yulon_the_jade_serpent",
+            "MONK",
+            "mistweaver"
         );
         this.AddDisambiguation("blink_any", "blink", "MAGE");
         this.AddDisambiguation(

--- a/src/simulationcraft/emiter.ts
+++ b/src/simulationcraft/emiter.ts
@@ -91,6 +91,10 @@ function IsTotem(name: string) {
         return true;
     } else if (sub(name, -6, -1) == "_totem") {
         return true;
+    } else if (name == "raise_dead") {
+        return true;
+    } else if (name == "summon_gargoyle") {
+        return true;
     }
     return false;
 }
@@ -359,6 +363,14 @@ export class Emiter {
             "deeper_stratagem_talent",
             "ROGUE"
         );
+        this.AddDisambiguation(
+            "gargoyle",
+            "summon_gargoyle",
+            "DEATHKNIGHT",
+            "unholy"
+        );
+        this.AddDisambiguation("ghoul", "raise_dead", "DEATHKNIGHT", "blood");
+        this.AddDisambiguation("ghoul", "raise_dead", "DEATHKNIGHT", "frost");
         this.AddDisambiguation(
             "dark_trasnformation",
             "dark_transformation",
@@ -3944,6 +3956,40 @@ export class Emiter {
                     action,
                     target
                 );
+            }
+        } else if (
+            className == "DEATHKNIGHT" &&
+            sub(operand, 1, 15) == "pet.army_ghoul."
+        ) {
+            const petOperand = sub(operand, 15);
+            const tokenIterator = gmatch(petOperand, OPERAND_TOKEN_PATTERN);
+            const token = tokenIterator();
+            if (token == "active") {
+                const spell = "army_of_the_dead";
+                // Army of the Dead ghouls last for 30 seconds after summoning.
+                code = format(
+                    "SpellCooldownDuration(%s) - SpellCooldown(%s) < 30",
+                    spell,
+                    spell
+                );
+                this.AddSymbol(annotation, spell);
+            }
+        } else if (
+            className == "DEATHKNIGHT" &&
+            sub(operand, 1, 15) == "pet.apoc_ghoul."
+        ) {
+            const petOperand = sub(operand, 15);
+            const tokenIterator = gmatch(petOperand, OPERAND_TOKEN_PATTERN);
+            const token = tokenIterator();
+            if (token == "active") {
+                const spell = "apocalypse";
+                // Apocalypse ghouls last for 15 seconds after summoning.
+                code = format(
+                    "SpellCooldownDuration(%s) - SpellCooldown(%s) < 15",
+                    spell,
+                    spell
+                );
+                this.AddSymbol(annotation, spell);
             }
         } else if (
             className == "DEMONHUNTER" &&


### PR DESCRIPTION
This pullup does the following:

* Adds totem support to every class since almost all classes can summon guardians which are treated in-game as totems.
* Try to pattern-match for `EmitOperandSpecial()` before falling through to the rest of the pet operand logic. This allows for
handling of special cases sooner in the flow.
* Fix translating death knight ghouls.
* Fix translating monk pets.

This fixes issue #761.