### PR TITLE
Improve translation of "desired_targets" from SimulationCraft.

### DIFF
--- a/src/engine/ast.ts
+++ b/src/engine/ast.ts
@@ -2065,7 +2065,7 @@ export class OvaleASTClass {
             tokenStream,
             "ParseAddListItem",
             annotation,
-            0,
+            1,
             checkListItemParameters
         );
         if (!positionalParams || !namedParams) return undefined;

--- a/src/engine/controls.ts
+++ b/src/engine/controls.ts
@@ -42,6 +42,7 @@ export class Controls {
                 name: name,
                 text: text,
                 defaultValue: defaultValue,
+                triggerEvaluation: true,
                 enabled: enabled,
             };
             this.checkBoxesByName[name] = checkBox;
@@ -70,6 +71,7 @@ export class Controls {
                 items: {},
                 itemsByName: {},
                 defaultValue: listName,
+                triggerEvaluation: true,
             };
             this.listsByName[listName] = list;
             insert(this.lists, list);

--- a/src/simulationcraft/definitions.ts
+++ b/src/simulationcraft/definitions.ts
@@ -672,10 +672,6 @@ export const MISC_OPERAND: LuaObj<MiscOperand> = {
     ["demon_soul_fragments"]: {
         name: "soulfragments", // GREATER/demon
     },
-    ["desired_targets"]: {
-        name: "enemies",
-        extraNamedParameter: { name: "tagged", value: 1 },
-    },
     ["druid"]: {
         name: "checkboxon",
         modifiers: {
@@ -1124,6 +1120,7 @@ export class Annotation implements InterruptAnnotation {
 
     sync?: LuaObj<ActionParseNode>;
 
+    desired_targets?: boolean;
     using_apl?: LuaObj<boolean>;
     currentVariable?: AstAddFunctionNode;
     variable: LuaObj<AstAddFunctionNode> = {};

--- a/src/simulationcraft/emiter.ts
+++ b/src/simulationcraft/emiter.ts
@@ -3908,7 +3908,10 @@ export class Emiter {
         target = (target && `${target}.`) || "";
         operand = lower(operand);
         let code;
-        if (
+        if (operand == "desired_targets") {
+            code = `${CamelCase(specialization)}DesiredTargets()`;
+            annotation.desired_targets = true;
+        } else if (
             className == "DEATHKNIGHT" &&
             operand == "dot.breath_of_sindragosa.ticking"
         ) {


### PR DESCRIPTION
This pullup should be merged without squashing. It fixes two bugs in `engine/controls.ts` and `engine/ast.ts` and also improves the translation of the SimC `desired_targets` operand in Ovale scripts (#236).

The default scripts should be regenerated after this pullup is complete.