### PR TITLE
fix(demonhunter): leaping not possible when rooted

### DIFF
--- a/src/scripts/ovale_demonhunter_spells.ts
+++ b/src/scripts/ovale_demonhunter_spells.ts
@@ -287,6 +287,8 @@ Define(arcane_torrent 202719)
     SpellRequire(death_sweep fury add=-20 enabled=(hastalent(first_blood_talent)))
 Define(frailty_debuff 247456)
     SpellInfo(frailty_debuff duration=20)
+#infernal_strike
+    SpellRequire(infernal_strike unusable set=1 enabled=(isrooted()))
 #spirit_bomb
     SpellRequire(spirit_bomb unusable set=1 enabled=(soulfragments() == 0))
 	SpellAddTargetDebuff(spirit_bomb frailty_debuff add=1)

--- a/src/scripts/ovale_demonhunter_spells.ts
+++ b/src/scripts/ovale_demonhunter_spells.ts
@@ -289,6 +289,8 @@ Define(frailty_debuff 247456)
     SpellInfo(frailty_debuff duration=20)
 #infernal_strike
     SpellRequire(infernal_strike unusable set=1 enabled=(isrooted()))
+#metamorphosis
+    SpellRequire(metamorphosis unusable set=1 enabled=(isrooted()))
 #spirit_bomb
     SpellRequire(spirit_bomb unusable set=1 enabled=(soulfragments() == 0))
 	SpellAddTargetDebuff(spirit_bomb frailty_debuff add=1)


### PR DESCRIPTION
You can't infernal strike or metamorphosis (the Havoc version) when rooted