### PR TITLE
fix(conditions): return a proper value for TimeToRunes()

### DIFF
--- a/src/states/conditions.ts
+++ b/src/states/conditions.ts
@@ -3894,7 +3894,7 @@ l    */
         if (seconds < 0) {
             seconds = 0;
         }
-        return ReturnConstant(seconds);
+        return ReturnValue(seconds, atTime, -1);
     };
 
     /**  Returns the value of the given snapshot stat.


### PR DESCRIPTION
TimeToRunes() returns a value of the number of seconds relative to
the current time. This should be a linear equation, not a simple
constant.