### PR TITLE
fix(best-action): always use the correct texture for actions

### DIFF
--- a/src/engine/best-action.ts
+++ b/src/engine/best-action.ts
@@ -100,8 +100,9 @@ export class OvaleBestActionClass {
         const [spellName] = GetItemSpell(itemId);
         if (node.cachedParams.named.texture) {
             result.actionTexture = `Interface\\Icons\\${node.cachedParams.named.texture}`;
+        } else {
+            result.actionTexture = GetItemIcon(itemId);
         }
-        result.actionTexture = result.actionTexture || GetItemIcon(itemId);
         result.actionInRange = IsItemInRange(itemId, target);
         [
             result.actionCooldownStart,
@@ -138,9 +139,9 @@ export class OvaleBestActionClass {
         }
         if (element.cachedParams.named.texture) {
             result.actionTexture = `Interface\\Icons\\${element.cachedParams.named.texture}`;
+        } else {
+            result.actionTexture = GetActionTexture(actionSlot);
         }
-        result.actionTexture =
-            result.actionTexture || GetActionTexture(actionSlot);
         result.actionInRange = IsActionInRange(actionSlot, target);
         [
             result.actionCooldownStart,
@@ -260,8 +261,9 @@ export class OvaleBestActionClass {
         setResultType(result, "action");
         if (element.cachedParams.named.texture) {
             result.actionTexture = `Interface\\Icons\\${element.cachedParams.named.texture}`;
+        } else {
+            result.actionTexture = GetSpellTexture(spellId);
         }
-        result.actionTexture = result.actionTexture || GetSpellTexture(spellId);
         result.actionInRange = this.OvaleSpells.IsSpellInRange(spellId, target);
         [
             result.actionCooldownStart,


### PR DESCRIPTION
The idiom that was used to set the texture was unnecessary when
the variables were all local, but is plain wrong when using
"result" fields because it would never overwrite a cached result's
texture. Simplify by using a simple if-else statement to set the
texture.

This fixes issue #749.