### PR TITLE
fix(druid): many fixes and improvements to feral script

### DIFF
--- a/src/engine/ast.ts
+++ b/src/engine/ast.ts
@@ -122,6 +122,7 @@ export const checkSpellInfo: TypeCheck<SpellInfoValues> = {
     fury: true,
     gcd: true,
     gcd_haste: true,
+    half_duration: true,
     haste: true,
     health: true,
     holypower: true,

--- a/src/engine/data.ts
+++ b/src/engine/data.ts
@@ -139,6 +139,7 @@ export interface SpellInfoValues
         SpellInfoPowerRefundValues {
     duration?: number;
     add_duration_combopoints?: number;
+    half_duration?: number;
     tick?: number;
     stacking?: number;
     max_stacks?: number;

--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -164,6 +164,20 @@ export class IoC {
             this.ovale,
             this.spellBook
         );
+        const combat = new OvaleCombatClass(
+            this.ovale,
+            this.debug,
+            this.spellBook
+        );
+        this.power = new OvalePowerClass(
+            this.debug,
+            this.ovale,
+            this.profiler,
+            this.data,
+            this.baseState,
+            this.spellBook,
+            combat
+        );
         this.state = new OvaleStateClass();
         this.aura = new OvaleAuraClass(
             this.state,
@@ -176,7 +190,8 @@ export class IoC {
             this.debug,
             this.ovale,
             this.profiler,
-            this.spellBook
+            this.spellBook,
+            this.power
         );
         this.stance = new OvaleStanceClass(
             this.debug,
@@ -226,11 +241,6 @@ export class IoC {
             this.ovale,
             this.debug
         );
-        const combat = new OvaleCombatClass(
-            this.ovale,
-            this.debug,
-            this.spellBook
-        );
         this.scripts = new OvaleScriptsClass(
             this.ovale,
             this.options,
@@ -264,15 +274,6 @@ export class IoC {
             this.spellBook,
             controls,
             this.scripts
-        );
-        this.power = new OvalePowerClass(
-            this.debug,
-            this.ovale,
-            this.profiler,
-            this.data,
-            this.baseState,
-            this.spellBook,
-            combat
         );
         this.stagger = new OvaleStaggerClass(
             this.ovale,
@@ -343,7 +344,7 @@ export class IoC {
             this.profiler,
             this.data,
             this.power,
-            this.runes,
+            this.runes
         );
         this.bestAction = new OvaleBestActionClass(
             this.equipment,

--- a/src/scripts/ovale_druid.ts
+++ b/src/scripts/ovale_druid.ts
@@ -911,8 +911,8 @@ AddFunction feralstealthmainactions
  {
   #pool_resource,for_next=1
   #rake,target_if=(dot.rake.pmultiplier<1.5|refreshable)&druid.rake.ticks_gained_on_refresh>2
-  if { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and ticksgainedonrefresh(rake) > 2 spell(rake)
-  unless { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and ticksgainedonrefresh(rake) > 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) }
+  if { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > 2 spell(rake)
+  unless { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) }
   {
    #brutal_slash,if=spell_targets.brutal_slash>2
    if enemies(tagged=1) > 2 spell(brutal_slash)
@@ -936,7 +936,7 @@ AddFunction feralstealthshortcdactions
 
 AddFunction feralstealthshortcdpostconditions
 {
- hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonsshortcdpostconditions() or { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and ticksgainedonrefresh(rake) > 2 and spell(rake) or not { { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and ticksgainedonrefresh(rake) > 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { enemies(tagged=1) > 2 and spell(brutal_slash) or combopoints() < 4 and spell(shred) }
+ hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonsshortcdpostconditions() or { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > 2 and spell(rake) or not { { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { enemies(tagged=1) > 2 and spell(brutal_slash) or combopoints() < 4 and spell(shred) }
 }
 
 AddFunction feralstealthcdactions
@@ -947,7 +947,7 @@ AddFunction feralstealthcdactions
 
 AddFunction feralstealthcdpostconditions
 {
- hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonscdpostconditions() or { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and ticksgainedonrefresh(rake) > 2 and spell(rake) or not { { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and ticksgainedonrefresh(rake) > 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { enemies(tagged=1) > 2 and spell(brutal_slash) or combopoints() < 4 and spell(shred) }
+ hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonscdpostconditions() or { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > 2 and spell(rake) or not { { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { enemies(tagged=1) > 2 and spell(brutal_slash) or combopoints() < 4 and spell(shred) }
 }
 
 ### actions.precombat
@@ -1005,9 +1005,9 @@ AddFunction feralfinishermainactions
  #variable,name=best_rip,value=0,if=talent.primal_wrath.enabled
  #cycling_variable,name=best_rip,op=max,value=druid.rip.ticks_gained_on_refresh,if=talent.primal_wrath.enabled
  #primal_wrath,if=druid.primal_wrath.ticks_gained_on_refresh>(variable.rip_ticks>?variable.best_rip)|spell_targets.primal_wrath>(3+1*talent.sabertooth.enabled)
- if ticksgainedonrefresh(primal_wrath) > rip_ticks() >? best_rip() or enemies(tagged=1) > 3 + 1 * talentpoints(sabertooth_talent) spell(primal_wrath)
+ if { target.ticksgainedonrefresh(rip primal_wrath) > rip_ticks() >? best_rip() or enemies(tagged=1) > 3 + 1 * talentpoints(sabertooth_talent) } and enemies(tagged=1) > 1 spell(primal_wrath)
  #rip,target_if=refreshable&druid.rip.ticks_gained_on_refresh>variable.rip_ticks&((buff.tigers_fury.up|cooldown.tigers_fury.remains>5)&(buff.bloodtalons.up|!talent.bloodtalons.enabled)&dot.rip.pmultiplier<=persistent_multiplier|!talent.sabertooth.enabled)
- if target.refreshable(rip) and ticksgainedonrefresh(rip) > rip_ticks() and { { buffpresent(tigers_fury) or spellcooldown(tigers_fury) > 5 } and { buffpresent(bloodtalons) or not hastalent(bloodtalons_talent) } and target.debuffpersistentmultiplier(rip) <= persistentmultiplier(rip) or not hastalent(sabertooth_talent) } spell(rip)
+ if target.refreshable(rip) and target.ticksgainedonrefresh(rip) > rip_ticks() and { { buffpresent(tigers_fury) or spellcooldown(tigers_fury) > 5 } and { buffpresent(bloodtalons) or not hastalent(bloodtalons_talent) } and target.debuffpersistentmultiplier(rip) <= persistentmultiplier(rip) or not hastalent(sabertooth_talent) } spell(rip)
  #ferocious_bite,max_energy=1,target_if=max:time_to_die
  if energy() >= energycost(ferocious_bite max=1) spell(ferocious_bite)
 }
@@ -1022,7 +1022,7 @@ AddFunction feralfinishershortcdactions
 
 AddFunction feralfinishershortcdpostconditions
 {
- { buffexpires(savage_roar) or buffremaining(savage_roar) < { combopoints() * 6 + 1 } * 0.3 } and spell(savage_roar) or { ticksgainedonrefresh(primal_wrath) > rip_ticks() >? best_rip() or enemies(tagged=1) > 3 + 1 * talentpoints(sabertooth_talent) } and spell(primal_wrath) or target.refreshable(rip) and ticksgainedonrefresh(rip) > rip_ticks() and { { buffpresent(tigers_fury) or spellcooldown(tigers_fury) > 5 } and { buffpresent(bloodtalons) or not hastalent(bloodtalons_talent) } and target.debuffpersistentmultiplier(rip) <= persistentmultiplier(rip) or not hastalent(sabertooth_talent) } and spell(rip) or energy() >= energycost(ferocious_bite max=1) and spell(ferocious_bite)
+ { buffexpires(savage_roar) or buffremaining(savage_roar) < { combopoints() * 6 + 1 } * 0.3 } and spell(savage_roar) or { { target.ticksgainedonrefresh(rip primal_wrath) > rip_ticks() >? best_rip() or enemies(tagged=1) > 3 + 1 * talentpoints(sabertooth_talent) } and enemies(tagged=1) > 1 } and spell(primal_wrath) or target.refreshable(rip) and target.ticksgainedonrefresh(rip) > rip_ticks() and { { buffpresent(tigers_fury) or spellcooldown(tigers_fury) > 5 } and { buffpresent(bloodtalons) or not hastalent(bloodtalons_talent) } and target.debuffpersistentmultiplier(rip) <= persistentmultiplier(rip) or not hastalent(sabertooth_talent) } and spell(rip) or energy() >= energycost(ferocious_bite max=1) and spell(ferocious_bite)
 }
 
 AddFunction feralfinishercdactions
@@ -1031,7 +1031,7 @@ AddFunction feralfinishercdactions
 
 AddFunction feralfinishercdpostconditions
 {
- { buffexpires(savage_roar) or buffremaining(savage_roar) < { combopoints() * 6 + 1 } * 0.3 } and spell(savage_roar) or { ticksgainedonrefresh(primal_wrath) > rip_ticks() >? best_rip() or enemies(tagged=1) > 3 + 1 * talentpoints(sabertooth_talent) } and spell(primal_wrath) or target.refreshable(rip) and ticksgainedonrefresh(rip) > rip_ticks() and { { buffpresent(tigers_fury) or spellcooldown(tigers_fury) > 5 } and { buffpresent(bloodtalons) or not hastalent(bloodtalons_talent) } and target.debuffpersistentmultiplier(rip) <= persistentmultiplier(rip) or not hastalent(sabertooth_talent) } and spell(rip) or energy() >= energycost(ferocious_bite max=1) and spell(ferocious_bite)
+ { buffexpires(savage_roar) or buffremaining(savage_roar) < { combopoints() * 6 + 1 } * 0.3 } and spell(savage_roar) or { { target.ticksgainedonrefresh(rip primal_wrath) > rip_ticks() >? best_rip() or enemies(tagged=1) > 3 + 1 * talentpoints(sabertooth_talent) } and enemies(tagged=1) > 1 } and spell(primal_wrath) or target.refreshable(rip) and target.ticksgainedonrefresh(rip) > rip_ticks() and { { buffpresent(tigers_fury) or spellcooldown(tigers_fury) > 5 } and { buffpresent(bloodtalons) or not hastalent(bloodtalons_talent) } and target.debuffpersistentmultiplier(rip) <= persistentmultiplier(rip) or not hastalent(sabertooth_talent) } and spell(rip) or energy() >= energycost(ferocious_bite max=1) and spell(ferocious_bite)
 }
 
 ### actions.filler
@@ -1141,11 +1141,11 @@ AddFunction feralcooldowncdpostconditions
 AddFunction feralbloodtalonsmainactions
 {
  #rake,target_if=(!ticking|(refreshable&persistent_multiplier>dot.rake.pmultiplier))&buff.bt_rake.down&druid.rake.ticks_gained_on_refresh>=2
- if { not target.debuffpresent(rake_debuff) or target.refreshable(rake_debuff) and persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and buffexpires(bt_rake_buff) and ticksgainedonrefresh(rake) >= 2 spell(rake)
+ if { not target.debuffpresent(rake_debuff) or target.refreshable(rake_debuff) and persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and buffexpires(bt_rake_buff) and target.ticksgainedonrefresh(rake_debuff) >= 2 spell(rake)
  #lunar_inspiration,target_if=refreshable&buff.bt_moonfire.down
  if target.refreshable(lunar_inspiration_feral) and buffexpires(bt_moonfire_buff) spell(lunar_inspiration_feral)
  #thrash_cat,target_if=refreshable&buff.bt_thrash.down&druid.thrash_cat.ticks_gained_on_refresh>8
- if target.refreshable(thrash_cat) and buffexpires(bt_thrash_buff) and ticksgainedonrefresh(thrash_cat) > 8 spell(thrash_cat)
+ if target.refreshable(thrash_cat) and buffexpires(bt_thrash_buff) and target.ticksgainedonrefresh(thrash_cat) > 8 spell(thrash_cat)
  #brutal_slash,if=buff.bt_brutal_slash.down
  if buffexpires(bt_brutal_slash_buff) spell(brutal_slash)
  #swipe_cat,if=buff.bt_swipe.down&spell_targets.swipe_cat>1
@@ -1168,7 +1168,7 @@ AddFunction feralbloodtalonsshortcdactions
 
 AddFunction feralbloodtalonsshortcdpostconditions
 {
- { not target.debuffpresent(rake_debuff) or target.refreshable(rake_debuff) and persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and buffexpires(bt_rake_buff) and ticksgainedonrefresh(rake) >= 2 and spell(rake) or target.refreshable(lunar_inspiration_feral) and buffexpires(bt_moonfire_buff) and spell(lunar_inspiration_feral) or target.refreshable(thrash_cat) and buffexpires(bt_thrash_buff) and ticksgainedonrefresh(thrash_cat) > 8 and spell(thrash_cat) or buffexpires(bt_brutal_slash_buff) and spell(brutal_slash) or buffexpires(bt_swipe_buff) and enemies(tagged=1) > 1 and spell(swipe_cat) or buffexpires(bt_shred_buff) and spell(shred) or buffexpires(bt_swipe_buff) and spell(swipe_cat) or buffexpires(bt_thrash_buff) and spell(thrash_cat)
+ { not target.debuffpresent(rake_debuff) or target.refreshable(rake_debuff) and persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and buffexpires(bt_rake_buff) and target.ticksgainedonrefresh(rake_debuff) >= 2 and spell(rake) or target.refreshable(lunar_inspiration_feral) and buffexpires(bt_moonfire_buff) and spell(lunar_inspiration_feral) or target.refreshable(thrash_cat) and buffexpires(bt_thrash_buff) and target.ticksgainedonrefresh(thrash_cat) > 8 and spell(thrash_cat) or buffexpires(bt_brutal_slash_buff) and spell(brutal_slash) or buffexpires(bt_swipe_buff) and enemies(tagged=1) > 1 and spell(swipe_cat) or buffexpires(bt_shred_buff) and spell(shred) or buffexpires(bt_swipe_buff) and spell(swipe_cat) or buffexpires(bt_thrash_buff) and spell(thrash_cat)
 }
 
 AddFunction feralbloodtalonscdactions
@@ -1177,7 +1177,7 @@ AddFunction feralbloodtalonscdactions
 
 AddFunction feralbloodtalonscdpostconditions
 {
- { not target.debuffpresent(rake_debuff) or target.refreshable(rake_debuff) and persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and buffexpires(bt_rake_buff) and ticksgainedonrefresh(rake) >= 2 and spell(rake) or target.refreshable(lunar_inspiration_feral) and buffexpires(bt_moonfire_buff) and spell(lunar_inspiration_feral) or target.refreshable(thrash_cat) and buffexpires(bt_thrash_buff) and ticksgainedonrefresh(thrash_cat) > 8 and spell(thrash_cat) or buffexpires(bt_brutal_slash_buff) and spell(brutal_slash) or buffexpires(bt_swipe_buff) and enemies(tagged=1) > 1 and spell(swipe_cat) or buffexpires(bt_shred_buff) and spell(shred) or buffexpires(bt_swipe_buff) and spell(swipe_cat) or buffexpires(bt_thrash_buff) and spell(thrash_cat)
+ { not target.debuffpresent(rake_debuff) or target.refreshable(rake_debuff) and persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and buffexpires(bt_rake_buff) and target.ticksgainedonrefresh(rake_debuff) >= 2 and spell(rake) or target.refreshable(lunar_inspiration_feral) and buffexpires(bt_moonfire_buff) and spell(lunar_inspiration_feral) or target.refreshable(thrash_cat) and buffexpires(bt_thrash_buff) and target.ticksgainedonrefresh(thrash_cat) > 8 and spell(thrash_cat) or buffexpires(bt_brutal_slash_buff) and spell(brutal_slash) or buffexpires(bt_swipe_buff) and enemies(tagged=1) > 1 and spell(swipe_cat) or buffexpires(bt_shred_buff) and spell(shred) or buffexpires(bt_swipe_buff) and spell(swipe_cat) or buffexpires(bt_thrash_buff) and spell(thrash_cat)
 }
 
 ### actions.default
@@ -1228,11 +1228,11 @@ AddFunction feral_defaultmainactions
        if buffpresent(apex_predators_craving_buff) and { not hastalent(bloodtalons_talent) or buffpresent(bloodtalons) } spell(ferocious_bite)
        #pool_resource,for_next=1
        #rake,target_if=(refreshable|persistent_multiplier>dot.rake.pmultiplier)&druid.rake.ticks_gained_on_refresh>spell_targets.swipe_cat*2-2
-       if { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and ticksgainedonrefresh(rake) > enemies(tagged=1) * 2 - 2 spell(rake)
-       unless { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and ticksgainedonrefresh(rake) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) }
+       if { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > enemies(tagged=1) * 2 - 2 spell(rake)
+       unless { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) }
        {
         #moonfire_cat,target_if=refreshable&druid.moonfire.ticks_gained_on_refresh>spell_targets.swipe_cat*2-2
-        if target.refreshable(moonfire_cat) and ticksgainedonrefresh(moonfire) > enemies(tagged=1) * 2 - 2 spell(moonfire_cat)
+        if target.refreshable(moonfire_cat) and target.ticksgainedonrefresh(moonfire_cat) > enemies(tagged=1) * 2 - 2 spell(moonfire_cat)
         #pool_resource,for_next=1
         #brutal_slash,if=(raid_event.adds.in>(1+max_charges-charges_fractional)*recharge_time)&(spell_targets.brutal_slash*action.brutal_slash.damage%action.brutal_slash.cost)>(action.shred.damage%action.shred.cost)
         if 600 > { 1 + spellmaxcharges(brutal_slash) - charges(brutal_slash count=0) } * spellchargecooldown(brutal_slash) and enemies(tagged=1) * damage(brutal_slash) / powercost(brutal_slash) > damage(shred) / powercost(shred) spell(brutal_slash)
@@ -1243,7 +1243,7 @@ AddFunction feral_defaultmainactions
          #shred,if=buff.clearcasting.up
          if buffpresent(clearcasting) spell(shred)
          #rake,target_if=buff.bs_inc.up&druid.rake.ticks_gained_on_refresh>2
-         if buffpresent(bs_inc_buff) and ticksgainedonrefresh(rake) > 2 spell(rake)
+         if buffpresent(bs_inc_buff) and target.ticksgainedonrefresh(rake_debuff) > 2 spell(rake)
          #call_action_list,name=filler
          feralfillermainactions()
         }
@@ -1258,7 +1258,7 @@ AddFunction feral_defaultmainactions
 
 AddFunction feral_defaultmainpostconditions
 {
- { buffpresent(shadowmeld) or buffpresent(prowl) } and feralstealthmainpostconditions() or feralcooldownmainpostconditions() or combopoints() >= 5 - _4cp_bite() and feralfinishermainpostconditions() or { buffpresent(bs_inc_buff) or buffpresent(sudden_ambush_buff) } and feralstealthmainpostconditions() or not { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and energy() + 3.5 * energyregenrate() + 40 * buffpresent(clearcasting) < 115 - 23 * buffpresent(incarnation_king_of_the_jungle) and buffcount(bt_buffs) == 0 } and { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonsmainpostconditions() or not { { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and ticksgainedonrefresh(rake) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { not { 600 > { 1 + spellmaxcharges(brutal_slash) - charges(brutal_slash count=0) } * spellchargecooldown(brutal_slash) and enemies(tagged=1) * damage(brutal_slash) / powercost(brutal_slash) > damage(shred) / powercost(shred) and { spellusable(brutal_slash) and spellcooldown(brutal_slash) < timetoenergyfor(brutal_slash) } } and feralfillermainpostconditions() } }
+ { buffpresent(shadowmeld) or buffpresent(prowl) } and feralstealthmainpostconditions() or feralcooldownmainpostconditions() or combopoints() >= 5 - _4cp_bite() and feralfinishermainpostconditions() or { buffpresent(bs_inc_buff) or buffpresent(sudden_ambush_buff) } and feralstealthmainpostconditions() or not { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and energy() + 3.5 * energyregenrate() + 40 * buffpresent(clearcasting) < 115 - 23 * buffpresent(incarnation_king_of_the_jungle) and buffcount(bt_buffs) == 0 } and { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonsmainpostconditions() or not { { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { not { 600 > { 1 + spellmaxcharges(brutal_slash) - charges(brutal_slash count=0) } * spellchargecooldown(brutal_slash) and enemies(tagged=1) * damage(brutal_slash) / powercost(brutal_slash) > damage(shred) / powercost(shred) and { spellusable(brutal_slash) and spellcooldown(brutal_slash) < timetoenergyfor(brutal_slash) } } and feralfillermainpostconditions() } }
 }
 
 AddFunction feral_defaultshortcdactions
@@ -1309,15 +1309,15 @@ AddFunction feral_defaultshortcdactions
           if combopoints() < 3 spell(feral_frenzy)
           #pool_resource,for_next=1
           #rake,target_if=(refreshable|persistent_multiplier>dot.rake.pmultiplier)&druid.rake.ticks_gained_on_refresh>spell_targets.swipe_cat*2-2
-          unless { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and ticksgainedonrefresh(rake) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) }
+          unless { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) }
           {
-           unless target.refreshable(moonfire_cat) and ticksgainedonrefresh(moonfire) > enemies(tagged=1) * 2 - 2 and spell(moonfire_cat)
+           unless target.refreshable(moonfire_cat) and target.ticksgainedonrefresh(moonfire_cat) > enemies(tagged=1) * 2 - 2 and spell(moonfire_cat)
            {
             #pool_resource,for_next=1
             #brutal_slash,if=(raid_event.adds.in>(1+max_charges-charges_fractional)*recharge_time)&(spell_targets.brutal_slash*action.brutal_slash.damage%action.brutal_slash.cost)>(action.shred.damage%action.shred.cost)
             unless 600 > { 1 + spellmaxcharges(brutal_slash) - charges(brutal_slash count=0) } * spellchargecooldown(brutal_slash) and enemies(tagged=1) * damage(brutal_slash) / powercost(brutal_slash) > damage(shred) / powercost(shred) and { spellusable(brutal_slash) and spellcooldown(brutal_slash) < timetoenergyfor(brutal_slash) }
             {
-             unless enemies(tagged=1) > 1 + buffpresent(bs_inc_buff) * 2 and spell(swipe_cat) or buffpresent(clearcasting) and spell(shred) or buffpresent(bs_inc_buff) and ticksgainedonrefresh(rake) > 2 and spell(rake)
+             unless enemies(tagged=1) > 1 + buffpresent(bs_inc_buff) * 2 and spell(swipe_cat) or buffpresent(clearcasting) and spell(shred) or buffpresent(bs_inc_buff) and target.ticksgainedonrefresh(rake_debuff) > 2 and spell(rake)
              {
               #call_action_list,name=filler
               feralfillershortcdactions()
@@ -1338,7 +1338,7 @@ AddFunction feral_defaultshortcdactions
 
 AddFunction feral_defaultshortcdpostconditions
 {
- buffpresent(heart_of_the_wild) and spell(starsurge) or not previousgcdspell(sunfire) and spell(sunfire) or buffexpires(cat_form) and spell(cat_form) or spell(prowl) or energy() < 40 and target.debuffremaining(rake_debuff) > 4.5 and { target.debuffremaining(rip) > 4.5 or combopoints() < 5 } and spellcooldown(tigers_fury) >= 4.5 and buffstacks(clearcasting) < 1 and not buffpresent(apex_predators_craving_buff) and not { not spellcooldown(convoke_the_spirits) > 0 } and owlweave() == 1 and spell(moonkin_form) or { buffpresent(shadowmeld) or buffpresent(prowl) } and feralstealthshortcdpostconditions() or feralcooldownshortcdpostconditions() or combopoints() >= 5 - _4cp_bite() and feralfinishershortcdpostconditions() or { buffpresent(bs_inc_buff) or buffpresent(sudden_ambush_buff) } and feralstealthshortcdpostconditions() or not { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and energy() + 3.5 * energyregenrate() + 40 * buffpresent(clearcasting) < 115 - 23 * buffpresent(incarnation_king_of_the_jungle) and buffcount(bt_buffs) == 0 } and { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonsshortcdpostconditions() or buffpresent(apex_predators_craving_buff) and { not hastalent(bloodtalons_talent) or buffpresent(bloodtalons) } and spell(ferocious_bite) or not { { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and ticksgainedonrefresh(rake) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { target.refreshable(moonfire_cat) and ticksgainedonrefresh(moonfire) > enemies(tagged=1) * 2 - 2 and spell(moonfire_cat) or not { 600 > { 1 + spellmaxcharges(brutal_slash) - charges(brutal_slash count=0) } * spellchargecooldown(brutal_slash) and enemies(tagged=1) * damage(brutal_slash) / powercost(brutal_slash) > damage(shred) / powercost(shred) and { spellusable(brutal_slash) and spellcooldown(brutal_slash) < timetoenergyfor(brutal_slash) } } and { enemies(tagged=1) > 1 + buffpresent(bs_inc_buff) * 2 and spell(swipe_cat) or buffpresent(clearcasting) and spell(shred) or buffpresent(bs_inc_buff) and ticksgainedonrefresh(rake) > 2 and spell(rake) or feralfillershortcdpostconditions() } } }
+ buffpresent(heart_of_the_wild) and spell(starsurge) or not previousgcdspell(sunfire) and spell(sunfire) or buffexpires(cat_form) and spell(cat_form) or spell(prowl) or energy() < 40 and target.debuffremaining(rake_debuff) > 4.5 and { target.debuffremaining(rip) > 4.5 or combopoints() < 5 } and spellcooldown(tigers_fury) >= 4.5 and buffstacks(clearcasting) < 1 and not buffpresent(apex_predators_craving_buff) and not { not spellcooldown(convoke_the_spirits) > 0 } and owlweave() == 1 and spell(moonkin_form) or { buffpresent(shadowmeld) or buffpresent(prowl) } and feralstealthshortcdpostconditions() or feralcooldownshortcdpostconditions() or combopoints() >= 5 - _4cp_bite() and feralfinishershortcdpostconditions() or { buffpresent(bs_inc_buff) or buffpresent(sudden_ambush_buff) } and feralstealthshortcdpostconditions() or not { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and energy() + 3.5 * energyregenrate() + 40 * buffpresent(clearcasting) < 115 - 23 * buffpresent(incarnation_king_of_the_jungle) and buffcount(bt_buffs) == 0 } and { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonsshortcdpostconditions() or buffpresent(apex_predators_craving_buff) and { not hastalent(bloodtalons_talent) or buffpresent(bloodtalons) } and spell(ferocious_bite) or not { { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { target.refreshable(moonfire_cat) and target.ticksgainedonrefresh(moonfire_cat) > enemies(tagged=1) * 2 - 2 and spell(moonfire_cat) or not { 600 > { 1 + spellmaxcharges(brutal_slash) - charges(brutal_slash count=0) } * spellchargecooldown(brutal_slash) and enemies(tagged=1) * damage(brutal_slash) / powercost(brutal_slash) > damage(shred) / powercost(shred) and { spellusable(brutal_slash) and spellcooldown(brutal_slash) < timetoenergyfor(brutal_slash) } } and { enemies(tagged=1) > 1 + buffpresent(bs_inc_buff) * 2 and spell(swipe_cat) or buffpresent(clearcasting) and spell(shred) or buffpresent(bs_inc_buff) and target.ticksgainedonrefresh(rake_debuff) > 2 and spell(rake) or feralfillershortcdpostconditions() } } }
 }
 
 AddFunction feral_defaultcdactions
@@ -1384,15 +1384,15 @@ AddFunction feral_defaultcdactions
         {
          #pool_resource,for_next=1
          #rake,target_if=(refreshable|persistent_multiplier>dot.rake.pmultiplier)&druid.rake.ticks_gained_on_refresh>spell_targets.swipe_cat*2-2
-         unless { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and ticksgainedonrefresh(rake) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) }
+         unless { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) }
          {
-          unless target.refreshable(moonfire_cat) and ticksgainedonrefresh(moonfire) > enemies(tagged=1) * 2 - 2 and spell(moonfire_cat)
+          unless target.refreshable(moonfire_cat) and target.ticksgainedonrefresh(moonfire_cat) > enemies(tagged=1) * 2 - 2 and spell(moonfire_cat)
           {
            #pool_resource,for_next=1
            #brutal_slash,if=(raid_event.adds.in>(1+max_charges-charges_fractional)*recharge_time)&(spell_targets.brutal_slash*action.brutal_slash.damage%action.brutal_slash.cost)>(action.shred.damage%action.shred.cost)
            unless 600 > { 1 + spellmaxcharges(brutal_slash) - charges(brutal_slash count=0) } * spellchargecooldown(brutal_slash) and enemies(tagged=1) * damage(brutal_slash) / powercost(brutal_slash) > damage(shred) / powercost(shred) and { spellusable(brutal_slash) and spellcooldown(brutal_slash) < timetoenergyfor(brutal_slash) }
            {
-            unless enemies(tagged=1) > 1 + buffpresent(bs_inc_buff) * 2 and spell(swipe_cat) or buffpresent(clearcasting) and spell(shred) or buffpresent(bs_inc_buff) and ticksgainedonrefresh(rake) > 2 and spell(rake)
+            unless enemies(tagged=1) > 1 + buffpresent(bs_inc_buff) * 2 and spell(swipe_cat) or buffpresent(clearcasting) and spell(shred) or buffpresent(bs_inc_buff) and target.ticksgainedonrefresh(rake_debuff) > 2 and spell(rake)
             {
              #call_action_list,name=filler
              feralfillercdactions()
@@ -1412,7 +1412,7 @@ AddFunction feral_defaultcdactions
 
 AddFunction feral_defaultcdpostconditions
 {
- buffpresent(heart_of_the_wild) and spell(starsurge) or not previousgcdspell(sunfire) and spell(sunfire) or buffexpires(cat_form) and spell(tigers_fury) or buffexpires(cat_form) and spell(cat_form) or spell(prowl) or energy() < 40 and target.debuffremaining(rake_debuff) > 4.5 and { target.debuffremaining(rip) > 4.5 or combopoints() < 5 } and spellcooldown(tigers_fury) >= 4.5 and buffstacks(clearcasting) < 1 and not buffpresent(apex_predators_craving_buff) and not { not spellcooldown(convoke_the_spirits) > 0 } and owlweave() == 1 and spell(moonkin_form) or { buffpresent(shadowmeld) or buffpresent(prowl) } and feralstealthcdpostconditions() or feralcooldowncdpostconditions() or combopoints() >= 5 - _4cp_bite() and feralfinishercdpostconditions() or { buffpresent(bs_inc_buff) or buffpresent(sudden_ambush_buff) } and feralstealthcdpostconditions() or not { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and energy() + 3.5 * energyregenrate() + 40 * buffpresent(clearcasting) < 115 - 23 * buffpresent(incarnation_king_of_the_jungle) and buffcount(bt_buffs) == 0 } and { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonscdpostconditions() or buffpresent(apex_predators_craving_buff) and { not hastalent(bloodtalons_talent) or buffpresent(bloodtalons) } and spell(ferocious_bite) or combopoints() < 3 and spell(feral_frenzy) or not { { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and ticksgainedonrefresh(rake) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { target.refreshable(moonfire_cat) and ticksgainedonrefresh(moonfire) > enemies(tagged=1) * 2 - 2 and spell(moonfire_cat) or not { 600 > { 1 + spellmaxcharges(brutal_slash) - charges(brutal_slash count=0) } * spellchargecooldown(brutal_slash) and enemies(tagged=1) * damage(brutal_slash) / powercost(brutal_slash) > damage(shred) / powercost(shred) and { spellusable(brutal_slash) and spellcooldown(brutal_slash) < timetoenergyfor(brutal_slash) } } and { enemies(tagged=1) > 1 + buffpresent(bs_inc_buff) * 2 and spell(swipe_cat) or buffpresent(clearcasting) and spell(shred) or buffpresent(bs_inc_buff) and ticksgainedonrefresh(rake) > 2 and spell(rake) or feralfillercdpostconditions() } } }
+ buffpresent(heart_of_the_wild) and spell(starsurge) or not previousgcdspell(sunfire) and spell(sunfire) or buffexpires(cat_form) and spell(tigers_fury) or buffexpires(cat_form) and spell(cat_form) or spell(prowl) or energy() < 40 and target.debuffremaining(rake_debuff) > 4.5 and { target.debuffremaining(rip) > 4.5 or combopoints() < 5 } and spellcooldown(tigers_fury) >= 4.5 and buffstacks(clearcasting) < 1 and not buffpresent(apex_predators_craving_buff) and not { not spellcooldown(convoke_the_spirits) > 0 } and owlweave() == 1 and spell(moonkin_form) or { buffpresent(shadowmeld) or buffpresent(prowl) } and feralstealthcdpostconditions() or feralcooldowncdpostconditions() or combopoints() >= 5 - _4cp_bite() and feralfinishercdpostconditions() or { buffpresent(bs_inc_buff) or buffpresent(sudden_ambush_buff) } and feralstealthcdpostconditions() or not { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and energy() + 3.5 * energyregenrate() + 40 * buffpresent(clearcasting) < 115 - 23 * buffpresent(incarnation_king_of_the_jungle) and buffcount(bt_buffs) == 0 } and { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonscdpostconditions() or buffpresent(apex_predators_craving_buff) and { not hastalent(bloodtalons_talent) or buffpresent(bloodtalons) } and spell(ferocious_bite) or combopoints() < 3 and spell(feral_frenzy) or not { { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { target.refreshable(moonfire_cat) and target.ticksgainedonrefresh(moonfire_cat) > enemies(tagged=1) * 2 - 2 and spell(moonfire_cat) or not { 600 > { 1 + spellmaxcharges(brutal_slash) - charges(brutal_slash count=0) } * spellchargecooldown(brutal_slash) and enemies(tagged=1) * damage(brutal_slash) / powercost(brutal_slash) > damage(shred) / powercost(shred) and { spellusable(brutal_slash) and spellcooldown(brutal_slash) < timetoenergyfor(brutal_slash) } } and { enemies(tagged=1) > 1 + buffpresent(bs_inc_buff) * 2 and spell(swipe_cat) or buffpresent(clearcasting) and spell(shred) or buffpresent(bs_inc_buff) and target.ticksgainedonrefresh(rake_debuff) > 2 and spell(rake) or feralfillercdpostconditions() } } }
 }
 
 ### Feral icons.
@@ -1618,8 +1618,8 @@ AddFunction feralstealthmainactions
  {
   #pool_resource,for_next=1
   #rake,target_if=(dot.rake.pmultiplier<1.5|refreshable)&druid.rake.ticks_gained_on_refresh>2
-  if { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and ticksgainedonrefresh(rake) > 2 spell(rake)
-  unless { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and ticksgainedonrefresh(rake) > 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) }
+  if { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > 2 spell(rake)
+  unless { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) }
   {
    #brutal_slash,if=spell_targets.brutal_slash>2
    if enemies(tagged=1) > 2 spell(brutal_slash)
@@ -1643,7 +1643,7 @@ AddFunction feralstealthshortcdactions
 
 AddFunction feralstealthshortcdpostconditions
 {
- hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonsshortcdpostconditions() or { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and ticksgainedonrefresh(rake) > 2 and spell(rake) or not { { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and ticksgainedonrefresh(rake) > 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { enemies(tagged=1) > 2 and spell(brutal_slash) or combopoints() < 4 and spell(shred) }
+ hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonsshortcdpostconditions() or { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > 2 and spell(rake) or not { { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { enemies(tagged=1) > 2 and spell(brutal_slash) or combopoints() < 4 and spell(shred) }
 }
 
 AddFunction feralstealthcdactions
@@ -1654,7 +1654,7 @@ AddFunction feralstealthcdactions
 
 AddFunction feralstealthcdpostconditions
 {
- hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonscdpostconditions() or { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and ticksgainedonrefresh(rake) > 2 and spell(rake) or not { { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and ticksgainedonrefresh(rake) > 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { enemies(tagged=1) > 2 and spell(brutal_slash) or combopoints() < 4 and spell(shred) }
+ hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonscdpostconditions() or { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > 2 and spell(rake) or not { { target.debuffpersistentmultiplier(rake_debuff) < 1.5 or target.refreshable(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { enemies(tagged=1) > 2 and spell(brutal_slash) or combopoints() < 4 and spell(shred) }
 }
 
 ### actions.precombat
@@ -1712,9 +1712,9 @@ AddFunction feralfinishermainactions
  #variable,name=best_rip,value=0,if=talent.primal_wrath.enabled
  #cycling_variable,name=best_rip,op=max,value=druid.rip.ticks_gained_on_refresh,if=talent.primal_wrath.enabled
  #primal_wrath,if=druid.primal_wrath.ticks_gained_on_refresh>(variable.rip_ticks>?variable.best_rip)|spell_targets.primal_wrath>(3+1*talent.sabertooth.enabled)
- if ticksgainedonrefresh(primal_wrath) > rip_ticks() >? best_rip() or enemies(tagged=1) > 3 + 1 * talentpoints(sabertooth_talent) spell(primal_wrath)
+ if { target.ticksgainedonrefresh(rip primal_wrath) > rip_ticks() >? best_rip() or enemies(tagged=1) > 3 + 1 * talentpoints(sabertooth_talent) } and enemies(tagged=1) > 1 spell(primal_wrath)
  #rip,target_if=refreshable&druid.rip.ticks_gained_on_refresh>variable.rip_ticks&((buff.tigers_fury.up|cooldown.tigers_fury.remains>5)&(buff.bloodtalons.up|!talent.bloodtalons.enabled)&dot.rip.pmultiplier<=persistent_multiplier|!talent.sabertooth.enabled)
- if target.refreshable(rip) and ticksgainedonrefresh(rip) > rip_ticks() and { { buffpresent(tigers_fury) or spellcooldown(tigers_fury) > 5 } and { buffpresent(bloodtalons) or not hastalent(bloodtalons_talent) } and target.debuffpersistentmultiplier(rip) <= persistentmultiplier(rip) or not hastalent(sabertooth_talent) } spell(rip)
+ if target.refreshable(rip) and target.ticksgainedonrefresh(rip) > rip_ticks() and { { buffpresent(tigers_fury) or spellcooldown(tigers_fury) > 5 } and { buffpresent(bloodtalons) or not hastalent(bloodtalons_talent) } and target.debuffpersistentmultiplier(rip) <= persistentmultiplier(rip) or not hastalent(sabertooth_talent) } spell(rip)
  #ferocious_bite,max_energy=1,target_if=max:time_to_die
  if energy() >= energycost(ferocious_bite max=1) spell(ferocious_bite)
 }
@@ -1729,7 +1729,7 @@ AddFunction feralfinishershortcdactions
 
 AddFunction feralfinishershortcdpostconditions
 {
- { buffexpires(savage_roar) or buffremaining(savage_roar) < { combopoints() * 6 + 1 } * 0.3 } and spell(savage_roar) or { ticksgainedonrefresh(primal_wrath) > rip_ticks() >? best_rip() or enemies(tagged=1) > 3 + 1 * talentpoints(sabertooth_talent) } and spell(primal_wrath) or target.refreshable(rip) and ticksgainedonrefresh(rip) > rip_ticks() and { { buffpresent(tigers_fury) or spellcooldown(tigers_fury) > 5 } and { buffpresent(bloodtalons) or not hastalent(bloodtalons_talent) } and target.debuffpersistentmultiplier(rip) <= persistentmultiplier(rip) or not hastalent(sabertooth_talent) } and spell(rip) or energy() >= energycost(ferocious_bite max=1) and spell(ferocious_bite)
+ { buffexpires(savage_roar) or buffremaining(savage_roar) < { combopoints() * 6 + 1 } * 0.3 } and spell(savage_roar) or { { target.ticksgainedonrefresh(rip primal_wrath) > rip_ticks() >? best_rip() or enemies(tagged=1) > 3 + 1 * talentpoints(sabertooth_talent) } and enemies(tagged=1) > 1 } and spell(primal_wrath) or target.refreshable(rip) and target.ticksgainedonrefresh(rip) > rip_ticks() and { { buffpresent(tigers_fury) or spellcooldown(tigers_fury) > 5 } and { buffpresent(bloodtalons) or not hastalent(bloodtalons_talent) } and target.debuffpersistentmultiplier(rip) <= persistentmultiplier(rip) or not hastalent(sabertooth_talent) } and spell(rip) or energy() >= energycost(ferocious_bite max=1) and spell(ferocious_bite)
 }
 
 AddFunction feralfinishercdactions
@@ -1738,7 +1738,7 @@ AddFunction feralfinishercdactions
 
 AddFunction feralfinishercdpostconditions
 {
- { buffexpires(savage_roar) or buffremaining(savage_roar) < { combopoints() * 6 + 1 } * 0.3 } and spell(savage_roar) or { ticksgainedonrefresh(primal_wrath) > rip_ticks() >? best_rip() or enemies(tagged=1) > 3 + 1 * talentpoints(sabertooth_talent) } and spell(primal_wrath) or target.refreshable(rip) and ticksgainedonrefresh(rip) > rip_ticks() and { { buffpresent(tigers_fury) or spellcooldown(tigers_fury) > 5 } and { buffpresent(bloodtalons) or not hastalent(bloodtalons_talent) } and target.debuffpersistentmultiplier(rip) <= persistentmultiplier(rip) or not hastalent(sabertooth_talent) } and spell(rip) or energy() >= energycost(ferocious_bite max=1) and spell(ferocious_bite)
+ { buffexpires(savage_roar) or buffremaining(savage_roar) < { combopoints() * 6 + 1 } * 0.3 } and spell(savage_roar) or { { target.ticksgainedonrefresh(rip primal_wrath) > rip_ticks() >? best_rip() or enemies(tagged=1) > 3 + 1 * talentpoints(sabertooth_talent) } and enemies(tagged=1) > 1 } and spell(primal_wrath) or target.refreshable(rip) and target.ticksgainedonrefresh(rip) > rip_ticks() and { { buffpresent(tigers_fury) or spellcooldown(tigers_fury) > 5 } and { buffpresent(bloodtalons) or not hastalent(bloodtalons_talent) } and target.debuffpersistentmultiplier(rip) <= persistentmultiplier(rip) or not hastalent(sabertooth_talent) } and spell(rip) or energy() >= energycost(ferocious_bite max=1) and spell(ferocious_bite)
 }
 
 ### actions.filler
@@ -1848,11 +1848,11 @@ AddFunction feralcooldowncdpostconditions
 AddFunction feralbloodtalonsmainactions
 {
  #rake,target_if=(!ticking|(refreshable&persistent_multiplier>dot.rake.pmultiplier))&buff.bt_rake.down&druid.rake.ticks_gained_on_refresh>=2
- if { not target.debuffpresent(rake_debuff) or target.refreshable(rake_debuff) and persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and buffexpires(bt_rake_buff) and ticksgainedonrefresh(rake) >= 2 spell(rake)
+ if { not target.debuffpresent(rake_debuff) or target.refreshable(rake_debuff) and persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and buffexpires(bt_rake_buff) and target.ticksgainedonrefresh(rake_debuff) >= 2 spell(rake)
  #lunar_inspiration,target_if=refreshable&buff.bt_moonfire.down
  if target.refreshable(lunar_inspiration_feral) and buffexpires(bt_moonfire_buff) spell(lunar_inspiration_feral)
  #thrash_cat,target_if=refreshable&buff.bt_thrash.down&druid.thrash_cat.ticks_gained_on_refresh>8
- if target.refreshable(thrash_cat) and buffexpires(bt_thrash_buff) and ticksgainedonrefresh(thrash_cat) > 8 spell(thrash_cat)
+ if target.refreshable(thrash_cat) and buffexpires(bt_thrash_buff) and target.ticksgainedonrefresh(thrash_cat) > 8 spell(thrash_cat)
  #brutal_slash,if=buff.bt_brutal_slash.down
  if buffexpires(bt_brutal_slash_buff) spell(brutal_slash)
  #swipe_cat,if=buff.bt_swipe.down&spell_targets.swipe_cat>1
@@ -1875,7 +1875,7 @@ AddFunction feralbloodtalonsshortcdactions
 
 AddFunction feralbloodtalonsshortcdpostconditions
 {
- { not target.debuffpresent(rake_debuff) or target.refreshable(rake_debuff) and persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and buffexpires(bt_rake_buff) and ticksgainedonrefresh(rake) >= 2 and spell(rake) or target.refreshable(lunar_inspiration_feral) and buffexpires(bt_moonfire_buff) and spell(lunar_inspiration_feral) or target.refreshable(thrash_cat) and buffexpires(bt_thrash_buff) and ticksgainedonrefresh(thrash_cat) > 8 and spell(thrash_cat) or buffexpires(bt_brutal_slash_buff) and spell(brutal_slash) or buffexpires(bt_swipe_buff) and enemies(tagged=1) > 1 and spell(swipe_cat) or buffexpires(bt_shred_buff) and spell(shred) or buffexpires(bt_swipe_buff) and spell(swipe_cat) or buffexpires(bt_thrash_buff) and spell(thrash_cat)
+ { not target.debuffpresent(rake_debuff) or target.refreshable(rake_debuff) and persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and buffexpires(bt_rake_buff) and target.ticksgainedonrefresh(rake_debuff) >= 2 and spell(rake) or target.refreshable(lunar_inspiration_feral) and buffexpires(bt_moonfire_buff) and spell(lunar_inspiration_feral) or target.refreshable(thrash_cat) and buffexpires(bt_thrash_buff) and target.ticksgainedonrefresh(thrash_cat) > 8 and spell(thrash_cat) or buffexpires(bt_brutal_slash_buff) and spell(brutal_slash) or buffexpires(bt_swipe_buff) and enemies(tagged=1) > 1 and spell(swipe_cat) or buffexpires(bt_shred_buff) and spell(shred) or buffexpires(bt_swipe_buff) and spell(swipe_cat) or buffexpires(bt_thrash_buff) and spell(thrash_cat)
 }
 
 AddFunction feralbloodtalonscdactions
@@ -1884,7 +1884,7 @@ AddFunction feralbloodtalonscdactions
 
 AddFunction feralbloodtalonscdpostconditions
 {
- { not target.debuffpresent(rake_debuff) or target.refreshable(rake_debuff) and persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and buffexpires(bt_rake_buff) and ticksgainedonrefresh(rake) >= 2 and spell(rake) or target.refreshable(lunar_inspiration_feral) and buffexpires(bt_moonfire_buff) and spell(lunar_inspiration_feral) or target.refreshable(thrash_cat) and buffexpires(bt_thrash_buff) and ticksgainedonrefresh(thrash_cat) > 8 and spell(thrash_cat) or buffexpires(bt_brutal_slash_buff) and spell(brutal_slash) or buffexpires(bt_swipe_buff) and enemies(tagged=1) > 1 and spell(swipe_cat) or buffexpires(bt_shred_buff) and spell(shred) or buffexpires(bt_swipe_buff) and spell(swipe_cat) or buffexpires(bt_thrash_buff) and spell(thrash_cat)
+ { not target.debuffpresent(rake_debuff) or target.refreshable(rake_debuff) and persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and buffexpires(bt_rake_buff) and target.ticksgainedonrefresh(rake_debuff) >= 2 and spell(rake) or target.refreshable(lunar_inspiration_feral) and buffexpires(bt_moonfire_buff) and spell(lunar_inspiration_feral) or target.refreshable(thrash_cat) and buffexpires(bt_thrash_buff) and target.ticksgainedonrefresh(thrash_cat) > 8 and spell(thrash_cat) or buffexpires(bt_brutal_slash_buff) and spell(brutal_slash) or buffexpires(bt_swipe_buff) and enemies(tagged=1) > 1 and spell(swipe_cat) or buffexpires(bt_shred_buff) and spell(shred) or buffexpires(bt_swipe_buff) and spell(swipe_cat) or buffexpires(bt_thrash_buff) and spell(thrash_cat)
 }
 
 ### actions.default
@@ -1935,11 +1935,11 @@ AddFunction feral_defaultmainactions
        if buffpresent(apex_predators_craving_buff) and { not hastalent(bloodtalons_talent) or buffpresent(bloodtalons) } spell(ferocious_bite)
        #pool_resource,for_next=1
        #rake,target_if=(refreshable|persistent_multiplier>dot.rake.pmultiplier)&druid.rake.ticks_gained_on_refresh>spell_targets.swipe_cat*2-2
-       if { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and ticksgainedonrefresh(rake) > enemies(tagged=1) * 2 - 2 spell(rake)
-       unless { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and ticksgainedonrefresh(rake) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) }
+       if { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > enemies(tagged=1) * 2 - 2 spell(rake)
+       unless { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) }
        {
         #moonfire_cat,target_if=refreshable&druid.moonfire.ticks_gained_on_refresh>spell_targets.swipe_cat*2-2
-        if target.refreshable(moonfire_cat) and ticksgainedonrefresh(moonfire) > enemies(tagged=1) * 2 - 2 spell(moonfire_cat)
+        if target.refreshable(moonfire_cat) and target.ticksgainedonrefresh(moonfire_cat) > enemies(tagged=1) * 2 - 2 spell(moonfire_cat)
         #pool_resource,for_next=1
         #brutal_slash,if=(raid_event.adds.in>(1+max_charges-charges_fractional)*recharge_time)&(spell_targets.brutal_slash*action.brutal_slash.damage%action.brutal_slash.cost)>(action.shred.damage%action.shred.cost)
         if 600 > { 1 + spellmaxcharges(brutal_slash) - charges(brutal_slash count=0) } * spellchargecooldown(brutal_slash) and enemies(tagged=1) * damage(brutal_slash) / powercost(brutal_slash) > damage(shred) / powercost(shred) spell(brutal_slash)
@@ -1950,7 +1950,7 @@ AddFunction feral_defaultmainactions
          #shred,if=buff.clearcasting.up
          if buffpresent(clearcasting) spell(shred)
          #rake,target_if=buff.bs_inc.up&druid.rake.ticks_gained_on_refresh>2
-         if buffpresent(bs_inc_buff) and ticksgainedonrefresh(rake) > 2 spell(rake)
+         if buffpresent(bs_inc_buff) and target.ticksgainedonrefresh(rake_debuff) > 2 spell(rake)
          #call_action_list,name=filler
          feralfillermainactions()
         }
@@ -1965,7 +1965,7 @@ AddFunction feral_defaultmainactions
 
 AddFunction feral_defaultmainpostconditions
 {
- { buffpresent(shadowmeld) or buffpresent(prowl) } and feralstealthmainpostconditions() or feralcooldownmainpostconditions() or combopoints() >= 5 - _4cp_bite() and feralfinishermainpostconditions() or { buffpresent(bs_inc_buff) or buffpresent(sudden_ambush_buff) } and feralstealthmainpostconditions() or not { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and energy() + 3.5 * energyregenrate() + 40 * buffpresent(clearcasting) < 115 - 23 * buffpresent(incarnation_king_of_the_jungle) and buffcount(bt_buffs) == 0 } and { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonsmainpostconditions() or not { { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and ticksgainedonrefresh(rake) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { not { 600 > { 1 + spellmaxcharges(brutal_slash) - charges(brutal_slash count=0) } * spellchargecooldown(brutal_slash) and enemies(tagged=1) * damage(brutal_slash) / powercost(brutal_slash) > damage(shred) / powercost(shred) and { spellusable(brutal_slash) and spellcooldown(brutal_slash) < timetoenergyfor(brutal_slash) } } and feralfillermainpostconditions() } }
+ { buffpresent(shadowmeld) or buffpresent(prowl) } and feralstealthmainpostconditions() or feralcooldownmainpostconditions() or combopoints() >= 5 - _4cp_bite() and feralfinishermainpostconditions() or { buffpresent(bs_inc_buff) or buffpresent(sudden_ambush_buff) } and feralstealthmainpostconditions() or not { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and energy() + 3.5 * energyregenrate() + 40 * buffpresent(clearcasting) < 115 - 23 * buffpresent(incarnation_king_of_the_jungle) and buffcount(bt_buffs) == 0 } and { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonsmainpostconditions() or not { { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { not { 600 > { 1 + spellmaxcharges(brutal_slash) - charges(brutal_slash count=0) } * spellchargecooldown(brutal_slash) and enemies(tagged=1) * damage(brutal_slash) / powercost(brutal_slash) > damage(shred) / powercost(shred) and { spellusable(brutal_slash) and spellcooldown(brutal_slash) < timetoenergyfor(brutal_slash) } } and feralfillermainpostconditions() } }
 }
 
 AddFunction feral_defaultshortcdactions
@@ -2016,15 +2016,15 @@ AddFunction feral_defaultshortcdactions
           if combopoints() < 3 spell(feral_frenzy)
           #pool_resource,for_next=1
           #rake,target_if=(refreshable|persistent_multiplier>dot.rake.pmultiplier)&druid.rake.ticks_gained_on_refresh>spell_targets.swipe_cat*2-2
-          unless { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and ticksgainedonrefresh(rake) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) }
+          unless { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) }
           {
-           unless target.refreshable(moonfire_cat) and ticksgainedonrefresh(moonfire) > enemies(tagged=1) * 2 - 2 and spell(moonfire_cat)
+           unless target.refreshable(moonfire_cat) and target.ticksgainedonrefresh(moonfire_cat) > enemies(tagged=1) * 2 - 2 and spell(moonfire_cat)
            {
             #pool_resource,for_next=1
             #brutal_slash,if=(raid_event.adds.in>(1+max_charges-charges_fractional)*recharge_time)&(spell_targets.brutal_slash*action.brutal_slash.damage%action.brutal_slash.cost)>(action.shred.damage%action.shred.cost)
             unless 600 > { 1 + spellmaxcharges(brutal_slash) - charges(brutal_slash count=0) } * spellchargecooldown(brutal_slash) and enemies(tagged=1) * damage(brutal_slash) / powercost(brutal_slash) > damage(shred) / powercost(shred) and { spellusable(brutal_slash) and spellcooldown(brutal_slash) < timetoenergyfor(brutal_slash) }
             {
-             unless enemies(tagged=1) > 1 + buffpresent(bs_inc_buff) * 2 and spell(swipe_cat) or buffpresent(clearcasting) and spell(shred) or buffpresent(bs_inc_buff) and ticksgainedonrefresh(rake) > 2 and spell(rake)
+             unless enemies(tagged=1) > 1 + buffpresent(bs_inc_buff) * 2 and spell(swipe_cat) or buffpresent(clearcasting) and spell(shred) or buffpresent(bs_inc_buff) and target.ticksgainedonrefresh(rake_debuff) > 2 and spell(rake)
              {
               #call_action_list,name=filler
               feralfillershortcdactions()
@@ -2045,7 +2045,7 @@ AddFunction feral_defaultshortcdactions
 
 AddFunction feral_defaultshortcdpostconditions
 {
- buffpresent(heart_of_the_wild) and spell(starsurge) or not previousgcdspell(sunfire) and spell(sunfire) or buffexpires(cat_form) and spell(cat_form) or spell(prowl) or energy() < 40 and target.debuffremaining(rake_debuff) > 4.5 and { target.debuffremaining(rip) > 4.5 or combopoints() < 5 } and spellcooldown(tigers_fury) >= 4.5 and buffstacks(clearcasting) < 1 and not buffpresent(apex_predators_craving_buff) and not { not spellcooldown(convoke_the_spirits) > 0 } and owlweave() == 1 and spell(moonkin_form) or { buffpresent(shadowmeld) or buffpresent(prowl) } and feralstealthshortcdpostconditions() or feralcooldownshortcdpostconditions() or combopoints() >= 5 - _4cp_bite() and feralfinishershortcdpostconditions() or { buffpresent(bs_inc_buff) or buffpresent(sudden_ambush_buff) } and feralstealthshortcdpostconditions() or not { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and energy() + 3.5 * energyregenrate() + 40 * buffpresent(clearcasting) < 115 - 23 * buffpresent(incarnation_king_of_the_jungle) and buffcount(bt_buffs) == 0 } and { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonsshortcdpostconditions() or buffpresent(apex_predators_craving_buff) and { not hastalent(bloodtalons_talent) or buffpresent(bloodtalons) } and spell(ferocious_bite) or not { { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and ticksgainedonrefresh(rake) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { target.refreshable(moonfire_cat) and ticksgainedonrefresh(moonfire) > enemies(tagged=1) * 2 - 2 and spell(moonfire_cat) or not { 600 > { 1 + spellmaxcharges(brutal_slash) - charges(brutal_slash count=0) } * spellchargecooldown(brutal_slash) and enemies(tagged=1) * damage(brutal_slash) / powercost(brutal_slash) > damage(shred) / powercost(shred) and { spellusable(brutal_slash) and spellcooldown(brutal_slash) < timetoenergyfor(brutal_slash) } } and { enemies(tagged=1) > 1 + buffpresent(bs_inc_buff) * 2 and spell(swipe_cat) or buffpresent(clearcasting) and spell(shred) or buffpresent(bs_inc_buff) and ticksgainedonrefresh(rake) > 2 and spell(rake) or feralfillershortcdpostconditions() } } }
+ buffpresent(heart_of_the_wild) and spell(starsurge) or not previousgcdspell(sunfire) and spell(sunfire) or buffexpires(cat_form) and spell(cat_form) or spell(prowl) or energy() < 40 and target.debuffremaining(rake_debuff) > 4.5 and { target.debuffremaining(rip) > 4.5 or combopoints() < 5 } and spellcooldown(tigers_fury) >= 4.5 and buffstacks(clearcasting) < 1 and not buffpresent(apex_predators_craving_buff) and not { not spellcooldown(convoke_the_spirits) > 0 } and owlweave() == 1 and spell(moonkin_form) or { buffpresent(shadowmeld) or buffpresent(prowl) } and feralstealthshortcdpostconditions() or feralcooldownshortcdpostconditions() or combopoints() >= 5 - _4cp_bite() and feralfinishershortcdpostconditions() or { buffpresent(bs_inc_buff) or buffpresent(sudden_ambush_buff) } and feralstealthshortcdpostconditions() or not { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and energy() + 3.5 * energyregenrate() + 40 * buffpresent(clearcasting) < 115 - 23 * buffpresent(incarnation_king_of_the_jungle) and buffcount(bt_buffs) == 0 } and { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonsshortcdpostconditions() or buffpresent(apex_predators_craving_buff) and { not hastalent(bloodtalons_talent) or buffpresent(bloodtalons) } and spell(ferocious_bite) or not { { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { target.refreshable(moonfire_cat) and target.ticksgainedonrefresh(moonfire_cat) > enemies(tagged=1) * 2 - 2 and spell(moonfire_cat) or not { 600 > { 1 + spellmaxcharges(brutal_slash) - charges(brutal_slash count=0) } * spellchargecooldown(brutal_slash) and enemies(tagged=1) * damage(brutal_slash) / powercost(brutal_slash) > damage(shred) / powercost(shred) and { spellusable(brutal_slash) and spellcooldown(brutal_slash) < timetoenergyfor(brutal_slash) } } and { enemies(tagged=1) > 1 + buffpresent(bs_inc_buff) * 2 and spell(swipe_cat) or buffpresent(clearcasting) and spell(shred) or buffpresent(bs_inc_buff) and target.ticksgainedonrefresh(rake_debuff) > 2 and spell(rake) or feralfillershortcdpostconditions() } } }
 }
 
 AddFunction feral_defaultcdactions
@@ -2091,15 +2091,15 @@ AddFunction feral_defaultcdactions
         {
          #pool_resource,for_next=1
          #rake,target_if=(refreshable|persistent_multiplier>dot.rake.pmultiplier)&druid.rake.ticks_gained_on_refresh>spell_targets.swipe_cat*2-2
-         unless { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and ticksgainedonrefresh(rake) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) }
+         unless { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) }
          {
-          unless target.refreshable(moonfire_cat) and ticksgainedonrefresh(moonfire) > enemies(tagged=1) * 2 - 2 and spell(moonfire_cat)
+          unless target.refreshable(moonfire_cat) and target.ticksgainedonrefresh(moonfire_cat) > enemies(tagged=1) * 2 - 2 and spell(moonfire_cat)
           {
            #pool_resource,for_next=1
            #brutal_slash,if=(raid_event.adds.in>(1+max_charges-charges_fractional)*recharge_time)&(spell_targets.brutal_slash*action.brutal_slash.damage%action.brutal_slash.cost)>(action.shred.damage%action.shred.cost)
            unless 600 > { 1 + spellmaxcharges(brutal_slash) - charges(brutal_slash count=0) } * spellchargecooldown(brutal_slash) and enemies(tagged=1) * damage(brutal_slash) / powercost(brutal_slash) > damage(shred) / powercost(shred) and { spellusable(brutal_slash) and spellcooldown(brutal_slash) < timetoenergyfor(brutal_slash) }
            {
-            unless enemies(tagged=1) > 1 + buffpresent(bs_inc_buff) * 2 and spell(swipe_cat) or buffpresent(clearcasting) and spell(shred) or buffpresent(bs_inc_buff) and ticksgainedonrefresh(rake) > 2 and spell(rake)
+            unless enemies(tagged=1) > 1 + buffpresent(bs_inc_buff) * 2 and spell(swipe_cat) or buffpresent(clearcasting) and spell(shred) or buffpresent(bs_inc_buff) and target.ticksgainedonrefresh(rake_debuff) > 2 and spell(rake)
             {
              #call_action_list,name=filler
              feralfillercdactions()
@@ -2119,7 +2119,7 @@ AddFunction feral_defaultcdactions
 
 AddFunction feral_defaultcdpostconditions
 {
- buffpresent(heart_of_the_wild) and spell(starsurge) or not previousgcdspell(sunfire) and spell(sunfire) or buffexpires(cat_form) and spell(tigers_fury) or buffexpires(cat_form) and spell(cat_form) or spell(prowl) or energy() < 40 and target.debuffremaining(rake_debuff) > 4.5 and { target.debuffremaining(rip) > 4.5 or combopoints() < 5 } and spellcooldown(tigers_fury) >= 4.5 and buffstacks(clearcasting) < 1 and not buffpresent(apex_predators_craving_buff) and not { not spellcooldown(convoke_the_spirits) > 0 } and owlweave() == 1 and spell(moonkin_form) or { buffpresent(shadowmeld) or buffpresent(prowl) } and feralstealthcdpostconditions() or feralcooldowncdpostconditions() or combopoints() >= 5 - _4cp_bite() and feralfinishercdpostconditions() or { buffpresent(bs_inc_buff) or buffpresent(sudden_ambush_buff) } and feralstealthcdpostconditions() or not { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and energy() + 3.5 * energyregenrate() + 40 * buffpresent(clearcasting) < 115 - 23 * buffpresent(incarnation_king_of_the_jungle) and buffcount(bt_buffs) == 0 } and { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonscdpostconditions() or buffpresent(apex_predators_craving_buff) and { not hastalent(bloodtalons_talent) or buffpresent(bloodtalons) } and spell(ferocious_bite) or combopoints() < 3 and spell(feral_frenzy) or not { { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and ticksgainedonrefresh(rake) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { target.refreshable(moonfire_cat) and ticksgainedonrefresh(moonfire) > enemies(tagged=1) * 2 - 2 and spell(moonfire_cat) or not { 600 > { 1 + spellmaxcharges(brutal_slash) - charges(brutal_slash count=0) } * spellchargecooldown(brutal_slash) and enemies(tagged=1) * damage(brutal_slash) / powercost(brutal_slash) > damage(shred) / powercost(shred) and { spellusable(brutal_slash) and spellcooldown(brutal_slash) < timetoenergyfor(brutal_slash) } } and { enemies(tagged=1) > 1 + buffpresent(bs_inc_buff) * 2 and spell(swipe_cat) or buffpresent(clearcasting) and spell(shred) or buffpresent(bs_inc_buff) and ticksgainedonrefresh(rake) > 2 and spell(rake) or feralfillercdpostconditions() } } }
+ buffpresent(heart_of_the_wild) and spell(starsurge) or not previousgcdspell(sunfire) and spell(sunfire) or buffexpires(cat_form) and spell(tigers_fury) or buffexpires(cat_form) and spell(cat_form) or spell(prowl) or energy() < 40 and target.debuffremaining(rake_debuff) > 4.5 and { target.debuffremaining(rip) > 4.5 or combopoints() < 5 } and spellcooldown(tigers_fury) >= 4.5 and buffstacks(clearcasting) < 1 and not buffpresent(apex_predators_craving_buff) and not { not spellcooldown(convoke_the_spirits) > 0 } and owlweave() == 1 and spell(moonkin_form) or { buffpresent(shadowmeld) or buffpresent(prowl) } and feralstealthcdpostconditions() or feralcooldowncdpostconditions() or combopoints() >= 5 - _4cp_bite() and feralfinishercdpostconditions() or { buffpresent(bs_inc_buff) or buffpresent(sudden_ambush_buff) } and feralstealthcdpostconditions() or not { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and energy() + 3.5 * energyregenrate() + 40 * buffpresent(clearcasting) < 115 - 23 * buffpresent(incarnation_king_of_the_jungle) and buffcount(bt_buffs) == 0 } and { hastalent(bloodtalons_talent) and buffexpires(bloodtalons) and feralbloodtalonscdpostconditions() or buffpresent(apex_predators_craving_buff) and { not hastalent(bloodtalons_talent) or buffpresent(bloodtalons) } and spell(ferocious_bite) or combopoints() < 3 and spell(feral_frenzy) or not { { target.refreshable(rake_debuff) or persistentmultiplier(rake_debuff) > target.debuffpersistentmultiplier(rake_debuff) } and target.ticksgainedonrefresh(rake_debuff) > enemies(tagged=1) * 2 - 2 and { spellusable(rake) and spellcooldown(rake) < timetoenergyfor(rake) } } and { target.refreshable(moonfire_cat) and target.ticksgainedonrefresh(moonfire_cat) > enemies(tagged=1) * 2 - 2 and spell(moonfire_cat) or not { 600 > { 1 + spellmaxcharges(brutal_slash) - charges(brutal_slash count=0) } * spellchargecooldown(brutal_slash) and enemies(tagged=1) * damage(brutal_slash) / powercost(brutal_slash) > damage(shred) / powercost(shred) and { spellusable(brutal_slash) and spellcooldown(brutal_slash) < timetoenergyfor(brutal_slash) } } and { enemies(tagged=1) > 1 + buffpresent(bs_inc_buff) * 2 and spell(swipe_cat) or buffpresent(clearcasting) and spell(shred) or buffpresent(bs_inc_buff) and target.ticksgainedonrefresh(rake_debuff) > 2 and spell(rake) or feralfillercdpostconditions() } } }
 }
 
 ### Feral icons.

--- a/src/scripts/ovale_druid_spells.ts
+++ b/src/scripts/ovale_druid_spells.ts
@@ -520,7 +520,7 @@ Define(frenzied_regeneration 22842)
 #incapacitating_roar    
     SpellRequire(incapacitating_roar unusable set=1 enabled=(not stance(druid_bear_form)))
 #prowl
-    SpellRequire(prowl unusable set=1 enabled=(stealthed()))
+    SpellRequire(prowl unusable set=1 enabled=(incombat() or buffpresent(prowl)))
 Define(thrash_bear 77758)
     SpellAddBuff(thrash_bear earthwarden_buff add=1 enabled=(talent(earthwarden_talent)))
     SpellAddTargetDebuff(thrash_bear thrash_bear_debuff add=1)

--- a/src/scripts/ovale_druid_spells.ts
+++ b/src/scripts/ovale_druid_spells.ts
@@ -523,6 +523,8 @@ Define(frenzied_regeneration 22842)
     SpellRequire(moonfire_cat unusable set=1 enabled=(not hastalent(lunar_inspiration_talent)))
 #prowl
     SpellRequire(prowl unusable set=1 enabled=(incombat() or buffpresent(prowl)))
+#rip
+    SpellInfo(rip add_duration_combopoints=4)
 Define(thrash_bear 77758)
     SpellAddBuff(thrash_bear earthwarden_buff add=1 enabled=(talent(earthwarden_talent)))
     SpellAddTargetDebuff(thrash_bear thrash_bear_debuff add=1)

--- a/src/scripts/ovale_druid_spells.ts
+++ b/src/scripts/ovale_druid_spells.ts
@@ -519,9 +519,6 @@ Define(frenzied_regeneration 22842)
     SpellRequire(frenzied_regeneration charge_cd set=30 enabled=(specialization(guardian)))
     SpellRequire(frenzied_regeneration cd set=30 enabled=(not specialization(guardian)))
     SpellAddBuff(frenzied_regeneration frenzied_regeneration add=1)
-    SpellRequire(frenzied_regeneration unusable set=1 enabled=(not stance(druid_bear_form)))
-#incapacitating_roar    
-    SpellRequire(incapacitating_roar unusable set=1 enabled=(not stance(druid_bear_form)))
 #prowl
     SpellRequire(prowl unusable set=1 enabled=(incombat() or buffpresent(prowl)))
 Define(thrash_bear 77758)
@@ -543,6 +540,28 @@ Define(thrash_bear_debuff 192090)
     SpellDamageBuff(rip tigers_fury set=1.15)
     SpellDamageBuff(thrash_cat tigers_fury set=1.15)
   
+#balance_affinity_talent
+Define(balance_affinity_talent_restoration 22366)
+    SpellRequire(moonkin_form unusable set=1 enabled=(not (specialization(balance) or hastalent(balance_affinity_talent) or hastalent(balance_affinity_talent_restoration))))
+    SpellRequire(starfire unusable set=1 enabled=(not (specialization(balance) or hastalent(balance_affinity_talent) or hastalent(balance_affinity_talent_restoration))))
+    SpellRequire(starsurge unusable set=1 enabled=(not (specialization(balance) or hastalent(balance_affinity_talent) or hastalent(balance_affinity_talent_restoration))))
+    SpellRequire(sunfire unusable set=1 enabled=(not (specialization(balance) or hastalent(balance_affinity_talent) or hastalent(balance_affinity_talent_restoration))))
+    SpellRequire(typhoon unusable set=1 enabled=(not (specialization(balance) or hastalent(balance_affinity_talent) or hastalent(balance_affinity_talent_restoration))))
+
+Define(feral_affinity_talent_balance 22155)
+#feral_affinity_talent_guardian
+Define(feral_affinity_talent_restoration 22367)
+    SpellRequire(maim unusable set=1 enabled=(not ((specialization(feral) or hastalent(feral_affinity_talent_balance) or hastalent(feral_affinity_talent_guardian) or hastalent(feral_affinity_talent_restoration)) and stance(druid_cat_form))))
+    SpellRequire(rake unusable set=1 enabled=(not ((specialization(feral) or hastalent(feral_affinity_talent_balance) or hastalent(feral_affinity_talent_guardian) or hastalent(feral_affinity_talent_restoration)) and stance(druid_cat_form))))
+    SpellRequire(rip unusable set=1 enabled=(not ((specialization(feral) or hastalent(feral_affinity_talent_balance) or hastalent(feral_affinity_talent_guardian) or hastalent(feral_affinity_talent_restoration)) and stance(druid_cat_form))))
+    SpellRequire(swipe_cat unusable set=1 enabled=(not ((specialization(feral) or hastalent(feral_affinity_talent_balance) or hastalent(feral_affinity_talent_guardian) or hastalent(feral_affinity_talent_restoration)) and stance(druid_cat_form))))
+
+Define(guardian_affinity_talent_balance 22157)
+Define(guardian_affinity_talent_feral 22158)
+Define(guardian_affinity_talent_restoration 22160)
+    SpellRequire(frenzied_regeneration unusable set=1 enabled=(not ((specialization(guardian) or hastalent(guardian_affinity_talent_balance) or hastalent(guardian_affinity_talent_feral) or hastalent(guardian_affinity_restoration)) and stance(druid_bear_form))))
+    SpellRequire(incapacitating_roar unusable set=1 enabled=(not ((specialization(guardian) or hastalent(guardian_affinity_talent_balance) or hastalent(guardian_affinity_talent_feral) or hastalent(guardian_affinity_restoration)) and stance(druid_bear_form))))
+
 SpellInfo(starfire inccounter="solar" resetcounter="lunar")
 SpellInfo(wrath inccounter="lunar" resetcounter="solar")
   SpellAddBuff(starfire eclipse_solar set=1 enabled=(counter("solar") == 1))

--- a/src/scripts/ovale_druid_spells.ts
+++ b/src/scripts/ovale_druid_spells.ts
@@ -510,6 +510,9 @@ Define(first_strike_soulbind 325069)
     // END
     code += `
     SpellRequire(berserk_0 replaced_by set=incarnation_guardian_of_ursoc enabled=(talent(incarnation_guardian_of_ursoc_talent)))
+#bloodtalons
+    SpellAddBuff(ferocious_bite bloodtalons add=-1 enabled=(specialization(feral) and hastalent(bloodtalons_talent)))
+    SpellAddBuff(rip bloodtalons add=-1 enabled=(specialization(feral) and hastalent(bloodtalons_talent)))
 Define(frenzied_regeneration 22842)
     SpellInfo(frenzied_regeneration duration=3)
     # TODO max_charges not implemented SpellRequire(frenzied_regeneration max_charges set=2 enabled=(specialization(guardian)))
@@ -528,6 +531,17 @@ Define(thrash_bear_debuff 192090)
     SpellInfo(thrash_bear_debuff duration=15 max_stacks=3)
     SpellRequire(pulverize unusable set=1 enabled=(not targetdebuffpresent(thrash_bear_debuff)))
     SpellAddTargetDebuff(pulverize thrash_bear_debuff add=-2)
+
+#snapshots
+    SpellDamageBuff(moonfire_cat tigers_fury set=1.15)
+    SpellDamageBuff(rake berserk_cat set=1.6)
+    SpellDamageBuff(rake incarnation_king_of_the_jungle set=1.6)
+    SpellDamageBuff(rake shadowmeld set=1.6)
+    SpellDamageBuff(rake prowl set=1.6)
+    SpellDamageBuff(rake tigers_fury set=1.15)
+    SpellDamageBuff(rip bloodtalons set=1.3 enabled=(specialization(feral) and hastalent(bloodtalons_talent)))
+    SpellDamageBuff(rip tigers_fury set=1.15)
+    SpellDamageBuff(thrash_cat tigers_fury set=1.15)
   
 SpellInfo(starfire inccounter="solar" resetcounter="lunar")
 SpellInfo(wrath inccounter="lunar" resetcounter="solar")

--- a/src/scripts/ovale_druid_spells.ts
+++ b/src/scripts/ovale_druid_spells.ts
@@ -524,7 +524,7 @@ Define(frenzied_regeneration 22842)
 #prowl
     SpellRequire(prowl unusable set=1 enabled=(incombat() or buffpresent(prowl)))
 #rip
-    SpellInfo(rip add_duration_combopoints=4)
+    SpellInfo(rip add_duration_combopoints=4 half_duration=primal_wrath)
 Define(thrash_bear 77758)
     SpellAddBuff(thrash_bear earthwarden_buff add=1 enabled=(talent(earthwarden_talent)))
     SpellAddTargetDebuff(thrash_bear thrash_bear_debuff add=1)

--- a/src/scripts/ovale_druid_spells.ts
+++ b/src/scripts/ovale_druid_spells.ts
@@ -519,6 +519,8 @@ Define(frenzied_regeneration 22842)
     SpellRequire(frenzied_regeneration charge_cd set=30 enabled=(specialization(guardian)))
     SpellRequire(frenzied_regeneration cd set=30 enabled=(not specialization(guardian)))
     SpellAddBuff(frenzied_regeneration frenzied_regeneration add=1)
+#moonfire_cat
+    SpellRequire(moonfire_cat unusable set=1 enabled=(not hastalent(lunar_inspiration_talent)))
 #prowl
     SpellRequire(prowl unusable set=1 enabled=(incombat() or buffpresent(prowl)))
 Define(thrash_bear 77758)

--- a/src/simulationcraft/definitions.ts
+++ b/src/simulationcraft/definitions.ts
@@ -687,10 +687,6 @@ export const MISC_OPERAND: LuaObj<MiscOperand> = {
                 type: MiscOperandModifierType.Parameter,
                 createOptions: true,
             },
-            ticks_gained_on_refresh: {
-                type: MiscOperandModifierType.Replace,
-                name: "ticksgainedonrefresh",
-            },
         },
         symbol: "",
     },

--- a/src/simulationcraft/emiter.ts
+++ b/src/simulationcraft/emiter.ts
@@ -1289,6 +1289,8 @@ export class Emiter {
                 bodyCode = "texture(spell_shadow_soulgem text=pickup)";
                 conditionCode = "soulfragments() > 0";
                 isSpellAction = false;
+            } else if (className == "DRUID" && action == "primal_wrath") {
+                conditionCode = "Enemies(tagged=1) > 1";
             } else if (className == "DRUID" && action == "pulverize") {
                 const debuffName = "thrash_bear_debuff";
                 this.AddSymbol(annotation, debuffName);

--- a/src/simulationcraft/emiter.ts
+++ b/src/simulationcraft/emiter.ts
@@ -4035,6 +4035,35 @@ export class Emiter {
             code =
                 "(not CheckBoxOn(opt_meta_only_during_boss) or IsBossFight()) and SpellCooldown(metamorphosis) <= 0";
             this.AddSymbol(annotation, "metamorphosis");
+        } else if (className == "DRUID" && truthy(match(operand, "^druid%."))) {
+            const tokenIterator = gmatch(operand, OPERAND_TOKEN_PATTERN);
+            tokenIterator(); // consume "druid."
+            const [name] = this.Disambiguate(
+                annotation,
+                lower(tokenIterator()),
+                annotation.classId,
+                annotation.specialization
+            );
+            const [debuffName] = this.Disambiguate(
+                annotation,
+                `${name}_debuff`,
+                annotation.classId,
+                annotation.specialization
+            );
+            const property = tokenIterator();
+            if (property == "ticks_gained_on_refresh") {
+                if (debuffName == "primal_wrath") {
+                    code = "target.TicksGainedOnRefresh(rip primal_wrath)";
+                    this.AddSymbol(annotation, "primal_wrath");
+                    this.AddSymbol(annotation, "rip");
+                } else {
+                    code = format(
+                        "target.TicksGainedOnRefresh(%s)",
+                        debuffName
+                    );
+                    this.AddSymbol(annotation, debuffName);
+                }
+            }
         } else if (
             className == "DRUID" &&
             operand == "buff.wild_charge_movement.down"

--- a/src/states/Aura.ts
+++ b/src/states/Aura.ts
@@ -1875,6 +1875,7 @@ export class OvaleAuraClass
                 const auraId = tonumber(auraIdKey);
                 const duration = this.GetBaseDuration(
                     auraId,
+                    spellId,
                     atTime,
                     spellcast
                 );
@@ -2183,6 +2184,7 @@ export class OvaleAuraClass
 
     GetBaseDuration(
         auraId: number,
+        spellId?: number | string,
         atTime?: number,
         spellcast?: PaperDollSnapshot
     ) {
@@ -2205,6 +2207,20 @@ export class OvaleAuraClass
                     (value + si.add_duration_combopoints * combopoints) * ratio;
             } else {
                 duration = value * ratio;
+            }
+        }
+        if (si && si.half_duration && spellId) {
+            if (this.ovaleData.buffSpellList[spellId]) {
+                for (const [id] of pairs(
+                    this.ovaleData.buffSpellList[spellId]
+                )) {
+                    if (id === si.half_duration) {
+                        duration = duration * 0.5;
+                        break;
+                    }
+                }
+            } else if (spellId === si.half_duration) {
+                duration = duration * 0.5;
             }
         }
         // Most aura durations are no longer reduced by haste

--- a/src/states/conditions.ts
+++ b/src/states/conditions.ts
@@ -4929,7 +4929,13 @@ l    */
                 this.OvaleAura.GetTickLength(auraId, this.OvalePaperDoll.next);
             const remainingTime = tick - (atTime - lastTickTime);
             if (remainingTime && remainingTime > 0) {
-                return ReturnConstant(remainingTime);
+                return ReturnValueBetween(
+                    aura.gain,
+                    INFINITY,
+                    tick,
+                    lastTickTime,
+                    -1
+                );
             }
         }
         return ReturnConstant(0);

--- a/src/states/conditions.ts
+++ b/src/states/conditions.ts
@@ -262,6 +262,7 @@ export class OvaleConditions {
             for (const [id] of pairs(spellList)) {
                 value = this.OvaleAura.GetBaseDuration(
                     id,
+                    undefined,
                     atTime,
                     this.OvalePaperDoll.next
                 );
@@ -272,6 +273,7 @@ export class OvaleConditions {
         } else {
             value = this.OvaleAura.GetBaseDuration(
                 auraId,
+                undefined,
                 atTime,
                 this.OvalePaperDoll.next
             );
@@ -3759,7 +3761,11 @@ l    */
             mine
         );
         if (aura) {
-            let baseDuration = this.OvaleAura.GetBaseDuration(auraId, atTime);
+            let baseDuration = this.OvaleAura.GetBaseDuration(
+                auraId,
+                undefined,
+                atTime
+            );
             if (baseDuration === INFINITY) {
                 baseDuration = aura.ending - aura.start;
             }

--- a/src/states/conditions.ts
+++ b/src/states/conditions.ts
@@ -262,6 +262,7 @@ export class OvaleConditions {
             for (const [id] of pairs(spellList)) {
                 value = this.OvaleAura.GetBaseDuration(
                     id,
+                    atTime,
                     this.OvalePaperDoll.next
                 );
                 if (value != INFINITY) {
@@ -271,6 +272,7 @@ export class OvaleConditions {
         } else {
             value = this.OvaleAura.GetBaseDuration(
                 auraId,
+                atTime,
                 this.OvalePaperDoll.next
             );
         }
@@ -3757,7 +3759,7 @@ l    */
             mine
         );
         if (aura) {
-            let baseDuration = this.OvaleAura.GetBaseDuration(auraId);
+            let baseDuration = this.OvaleAura.GetBaseDuration(auraId, atTime);
             if (baseDuration === INFINITY) {
                 baseDuration = aura.ending - aura.start;
             }


### PR DESCRIPTION
This pullup makes many fixes to the feral druid spell definitions,
adds an implementation for `TicksGainedOnRefresh()` used by the
default feral scripts, and fixes the importer to emit the correct
script code for `druid.<spell>.ticks_gained_on_refresh`.

The feral script seems usable now with some light testing against
a target dummy on a level 52 feral druid.

This fixes issue #777.