### PR TITLE
fix: properly check for known spells in InUsableSpell()

### DIFF
--- a/src/states/SpellBook.ts
+++ b/src/states/SpellBook.ts
@@ -27,6 +27,7 @@ import {
     HasPetSpells,
     IsHarmfulSpell,
     IsHelpfulSpell,
+    IsSpellKnown,
     BOOKTYPE_PET,
     BOOKTYPE_SPELL,
     MAX_TALENT_TIERS,
@@ -391,7 +392,22 @@ export class OvaleSpellBookClass {
         return (spellId && this.isHelpful[spellId] && true) || false;
     }
     IsKnownSpell(spellId: number): boolean {
-        return (spellId && this.spell[spellId] && true) || false;
+        /**
+         * A spell is known if it's in the spellbook, or is a temporary spell
+         * or action granted by an encounter that may not be in the spellbook.
+         */
+
+        let isKnown = this.spell[spellId] !== undefined;
+        if (!isKnown) {
+            isKnown = IsSpellKnown(spellId) || IsSpellKnown(spellId, true);
+            if (isKnown) {
+                this.tracer.Log(
+                    "Spell ID '%s' is not in the spellbook, but is still known.",
+                    spellId
+                );
+            }
+        }
+        return (isKnown && true) || false;
     }
     IsKnownTalent(talentId: number): boolean {
         return (talentId && this.talentPoints[talentId] && true) || false;

--- a/src/states/Spells.ts
+++ b/src/states/Spells.ts
@@ -152,9 +152,12 @@ export class OvaleSpellsClass implements StateModule {
     ): [boolean, boolean] {
         this.profiler.StartProfiling("OvaleSpellBook_state_IsUsableSpell");
         let [isUsable, noMana] = [false, false];
-        let isKnown = this.OvaleSpellBook.IsKnownSpell(spellId);
+        const isKnown = this.OvaleSpellBook.IsKnownSpell(spellId);
         const si = this.ovaleData.spellInfo[spellId];
-        if (si && isKnown) {
+        if (!isKnown) {
+            this.tracer.Log("Spell ID '%s' is not known.", spellId);
+            [isUsable, noMana] = [false, false];
+        } else if (si !== undefined) {
             const unusable = this.ovaleData.GetSpellInfoProperty(
                 spellId,
                 atTime,
@@ -189,20 +192,7 @@ export class OvaleSpellsClass implements StateModule {
                 }
             }
         } else {
-            const [index, bookType] = this.OvaleSpellBook.GetSpellBookIndex(
-                spellId
-            );
-            if (index && bookType) {
-                [isUsable, noMana] = IsUsableSpell(index, bookType);
-            } else if (isKnown) {
-                const name = this.OvaleSpellBook.GetSpellName(spellId);
-                if (name) {
-                    [isUsable, noMana] = IsUsableSpell(name);
-                }
-            } else {
-                this.tracer.Log("Spell ID '%s' is not known.", spellId);
-                [isUsable, noMana] = [false, false];
-            }
+            [isUsable, noMana] = IsUsableSpell(spellId);
         }
         this.profiler.StopProfiling("OvaleSpellBook_state_IsUsableSpell");
         return [isUsable, noMana];


### PR DESCRIPTION
Revert 86439eb31f273ab217bfd4decce845f88b09f7f2 and fix the
underlying problem in a different way. That commit used the WoW
IsUsableSpell() API function to determine whether a spell is known,
but that returns false if the spell is genuinely not usable due to
either cooldown or power requirements. Fix this in a better way by
teaching SpellBook.ts:IsKnownSpell() to check for a spell being
known to the player even if it's not in the spellbook by using the
WoW IsSpellKnown() API function.

While here, adjust IsUsableSpell() so that there is only a single
exit point from the function to make the profiler stats work
correctly.