### PR TITLE
fix(rogue): outlaw rogues stun using a different spell

### DIFF
--- a/src/scripts/ovale_rogue.ts
+++ b/src/scripts/ovale_rogue.ts
@@ -69,7 +69,7 @@ AddFunction assassinationinterruptactions
  {
   if target.inrange(kick) and target.isinterruptible() spell(kick)
   if target.inrange(cheap_shot) and not target.classification(worldboss) spell(cheap_shot)
-  if target.inrange(kidney_shot) and not target.classification(worldboss) and combopoints() >= 1 spell(kidney_shot)
+  if target.inrange(kidney_shot) and not target.classification(worldboss) spell(kidney_shot)
   if target.inrange(quaking_palm) and not target.classification(worldboss) spell(quaking_palm)
  }
 }
@@ -685,7 +685,7 @@ AddFunction outlawinterruptactions
  {
   if target.inrange(kick) and target.isinterruptible() spell(kick)
   if target.inrange(cheap_shot) and not target.classification(worldboss) spell(cheap_shot)
-  if target.inrange(between_the_eyes) and not target.classification(worldboss) and combopoints() >= 1 spell(between_the_eyes)
+  if target.inrange(kidney_shot) and not target.classification(worldboss) spell(kidney_shot)
   if target.inrange(quaking_palm) and not target.classification(worldboss) spell(quaking_palm)
   if target.inrange(gouge) and not target.classification(worldboss) spell(gouge)
  }
@@ -1237,7 +1237,7 @@ AddFunction subtletyinterruptactions
  {
   if target.inrange(kick) and target.isinterruptible() spell(kick)
   if target.inrange(cheap_shot) and not target.classification(worldboss) spell(cheap_shot)
-  if target.inrange(kidney_shot) and not target.classification(worldboss) and combopoints() >= 1 spell(kidney_shot)
+  if target.inrange(kidney_shot) and not target.classification(worldboss) spell(kidney_shot)
   if target.inrange(quaking_palm) and not target.classification(worldboss) spell(quaking_palm)
  }
 }

--- a/src/simulationcraft/generator.ts
+++ b/src/simulationcraft/generator.ts
@@ -493,28 +493,16 @@ export class Generator {
             });
             if (annotation.specialization == "outlaw") {
                 insert(interrupts, {
-                    name: "between_the_eyes",
-                    stun: 1,
-                    order: 30,
-                    extraCondition: "ComboPoints() >= 1",
-                });
-                insert(interrupts, {
                     name: "gouge",
                     incapacitate: 1,
                     order: 100,
                 });
             }
-            if (
-                annotation.specialization == "assassination" ||
-                annotation.specialization == "subtlety"
-            ) {
-                insert(interrupts, {
-                    name: "kidney_shot",
-                    stun: 1,
-                    order: 30,
-                    extraCondition: "ComboPoints() >= 1",
-                });
-            }
+            insert(interrupts, {
+                name: "kidney_shot",
+                stun: 1,
+                order: 30,
+            });
         }
         if (annotation.wind_shear == "SHAMAN") {
             insert(interrupts, {


### PR DESCRIPTION
Outlaw rogues can't stun anymore with Between the Eyes, but can use
Kidney Shot instead.