### PR TITLE
fix: follow 'replaced_by' SpellInfo chain to the final replacement

### DIFF
--- a/src/engine/best-action.ts
+++ b/src/engine/best-action.ts
@@ -197,11 +197,11 @@ export class OvaleBestActionClass {
         let si = this.ovaleData.spellInfo[spellId];
         let replacedSpellId = undefined;
         if (si) {
-            const MAX_GUARD = 20;
+            const maxGuard = 20;
             let guard = 0;
             let replacementId = spellId;
             let id: number | undefined = replacementId;
-            while (id !== undefined && guard < MAX_GUARD) {
+            while (id !== undefined && guard < maxGuard) {
                 guard = guard + 1;
                 replacementId = id;
                 id = this.ovaleData.getSpellInfoProperty(
@@ -211,7 +211,7 @@ export class OvaleBestActionClass {
                     targetGUID
                 );
             }
-            if (guard >= MAX_GUARD) {
+            if (guard >= maxGuard) {
                 oneTimeMessage(
                     "Recursive 'replaced_by' chain for spell ID '%s'.",
                     spellId

--- a/src/engine/best-action.ts
+++ b/src/engine/best-action.ts
@@ -25,7 +25,7 @@ import {
 } from "./ast";
 import { OvaleCooldownClass } from "../states/Cooldown";
 import { OvaleSpellsClass } from "../states/Spells";
-import { isNumber, isString } from "../tools/tools";
+import { isNumber, isString, oneTimeMessage } from "../tools/tools";
 import { OvaleClass } from "../Ovale";
 import { AceModule } from "@wowts/tsaddon";
 import { Guids } from "./guid";
@@ -197,15 +197,28 @@ export class OvaleBestActionClass {
         let si = this.ovaleData.spellInfo[spellId];
         let replacedSpellId = undefined;
         if (si) {
-            const replacement = this.ovaleData.getSpellInfoProperty(
-                spellId,
-                atTime,
-                "replaced_by",
-                targetGUID
-            );
-            if (replacement) {
+            const MAX_GUARD = 20;
+            let guard = 0;
+            let replacementId = spellId;
+            let id: number | undefined = replacementId;
+            while (id !== undefined && guard < MAX_GUARD) {
+                guard = guard + 1;
+                replacementId = id;
+                id = this.ovaleData.getSpellInfoProperty(
+                    <number>replacementId,
+                    atTime,
+                    "replaced_by",
+                    targetGUID
+                );
+            }
+            if (guard >= MAX_GUARD) {
+                oneTimeMessage(
+                    "Recursive 'replaced_by' chain for spell ID '%s'.",
+                    spellId
+                );
+            } else if (replacementId != spellId) {
                 replacedSpellId = spellId;
-                spellId = replacement;
+                spellId = replacementId;
                 si = this.ovaleData.spellInfo[spellId];
                 this.tracer.log(
                     "Spell ID '%s' is replaced by spell ID '%s'.",


### PR DESCRIPTION
When a spell is annotated to be replaced by another spell using the
SpellInfo parameter 'replaced_by', keep searching along the chain
of spells for other 'replaced_by' directives until we reach the
final replacement spell.

This should fix issue #833.