### PR TITLE
Fix for legendary power

### DIFF
--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -424,7 +424,7 @@ export class IoC {
         );
         this.recount = new OvaleRecountClass(this.ovale, this.score);
         const covenant = new Covenant(this.ovale, this.debug);
-        const runeforge = new Runeforge(this.debug);
+        const runeforge = new Runeforge(this.ovale, this.debug);
         const conduit = new Conduit(this.debug);
         this.conditions = new OvaleConditions(
             this.condition,

--- a/src/states/runeforge.ts
+++ b/src/states/runeforge.ts
@@ -1,6 +1,12 @@
-import { ipairs, LuaArray, tonumber, unpack } from "@wowts/lua";
+import { pairs, ipairs, LuaArray, tonumber, unpack } from "@wowts/lua";
 import { concat, insert } from "@wowts/table";
-import { C_LegendaryCrafting, RuneforgePowerState } from "@wowts/wow-mock";
+import {
+    C_LegendaryCrafting,
+    GetInventoryItemQuality,
+    GetInventoryItemLink,
+    INVSLOT_FIRST_EQUIPPED,
+    INVSLOT_LAST_EQUIPPED,
+} from "@wowts/wow-mock";
 import { OptionUiGroup } from "../ui/acegui-helpers";
 import {
     ConditionFunction,
@@ -9,9 +15,16 @@ import {
 } from "../engine/condition";
 import { DebugTools } from "../engine/debug";
 import { isNumber, oneTimeMessage } from "../tools/tools";
+import { OvaleClass } from "../Ovale";
+import { AceModule } from "@wowts/tsaddon";
+import aceEvent, { AceEvent } from "@wowts/ace_event-3.0";
+import { match } from "@wowts/string";
 
 export class Runeforge {
-    private debugOptions: OptionUiGroup = {
+    private module: AceModule & AceEvent;
+    private equippedLegendaryById: LuaArray<number> = {};
+
+    private debugRuneforges: OptionUiGroup = {
         type: "group",
         name: "Runeforges",
         args: {
@@ -39,9 +52,72 @@ export class Runeforge {
         },
     };
 
-    constructor(debug: DebugTools) {
-        debug.defaultOptions.args["runeforge"] = this.debugOptions;
+    private debugLegendaries: OptionUiGroup = {
+        type: "group",
+        name: "Legendaries",
+        args: {
+            legendaries: {
+                type: "input",
+                name: "Legendaries",
+                multiline: 25,
+                width: "full",
+                get: () => {
+                    const output: LuaArray<string> = {};
+                    for (const [id, v] of pairs(this.equippedLegendaryById)) {
+                        insert(output, `${id}: ${v}`);
+                    }
+                    return concat(output, "\n");
+                },
+            },
+        },
+    };
+
+    constructor(ovale: OvaleClass, debug: DebugTools) {
+        debug.defaultOptions.args["runeforge"] = this.debugRuneforges;
+        debug.defaultOptions.args["legendaries"] = this.debugLegendaries;
+
+        this.module = ovale.createModule(
+            "OvaleRuneforge",
+            this.handleInitialize,
+            this.handleDisable,
+            aceEvent
+        );
     }
+
+    private handleInitialize = () => {
+        this.module.RegisterMessage(
+            "Ovale_EquipmentChanged",
+            this.updateEquippedItems
+        );
+    };
+    private handleDisable = () => {
+        this.module.UnregisterMessage("Ovale_EquipmentChanged");
+    };
+    private updateEquippedItems = () => {
+        this.equippedLegendaryById = {};
+        // we need to scan for legendaries now
+        for (
+            let slotId = INVSLOT_FIRST_EQUIPPED;
+            slotId <= INVSLOT_LAST_EQUIPPED;
+            slotId += 1
+        ) {
+            if (GetInventoryItemQuality("player", slotId) == 5) {
+                const [newItemLink] = match(
+                    GetInventoryItemLink("player", slotId),
+                    "item:([%-?%d:]+)"
+                );
+                if (newItemLink) {
+                    const [newLegendaryId] = match(
+                        newItemLink,
+                        "%d*:%d*:%d*:%d*:%d*:%d*:%d*:%d*:%d*:%d*:%d*:%d*:%d*:(%d*):"
+                    );
+                    this.equippedLegendaryById[
+                        tonumber(newLegendaryId)
+                    ] = tonumber(slotId);
+                }
+            }
+        }
+    };
 
     registerConditions(condition: OvaleConditionClass) {
         condition.registerCondition(
@@ -53,16 +129,15 @@ export class Runeforge {
     }
 
     private equippedRuneforge: ConditionFunction = (positionalParameters) => {
-        const [powerId] = unpack(positionalParameters);
-        if (!isNumber(powerId)) {
-            oneTimeMessage(`${powerId} is not defined in EquippedRuneforge`);
+        const [bonusItemId] = unpack(positionalParameters);
+        if (!isNumber(bonusItemId)) {
+            oneTimeMessage(
+                `${bonusItemId} is not defined in EquippedRuneforge`
+            );
             return [];
         }
-        const runeforgePower = C_LegendaryCrafting.GetRuneforgePowerInfo(
-            tonumber(powerId)
-        );
         return returnBoolean(
-            runeforgePower.state === RuneforgePowerState.Available
+            this.equippedLegendaryById[bonusItemId] !== undefined
         );
     };
 }


### PR DESCRIPTION
Imported runeforge ids in spells.ts correspond to the equipped bonus item id for the respective legendary item.
Therefore we want to scan (and keep in memory) which legendaries we have equipped and which bonus item id is specified. We look it up with an itemlink scan.