### PR TITLE
feat(runeforge): allow using runeforge power IDs in scripts

### DIFF
--- a/src/states/runeforge.ts
+++ b/src/states/runeforge.ts
@@ -1,3 +1,4 @@
+import aceEvent, { AceEvent } from "@wowts/ace_event-3.0";
 import {
     LuaArray,
     ipairs,
@@ -8,8 +9,9 @@ import {
     wipe,
 } from "@wowts/lua";
 import { concat, insert } from "@wowts/table";
+import { AceModule } from "@wowts/tsaddon";
 import { C_LegendaryCrafting, Enum } from "@wowts/wow-mock";
-import { OptionUiGroup } from "../ui/acegui-helpers";
+import { OvaleClass } from "../Ovale";
 import {
     ConditionFunction,
     OvaleConditionClass,
@@ -17,9 +19,7 @@ import {
 } from "../engine/condition";
 import { DebugTools } from "../engine/debug";
 import { isNumber, oneTimeMessage } from "../tools/tools";
-import { OvaleClass } from "../Ovale";
-import { AceModule } from "@wowts/tsaddon";
-import aceEvent, { AceEvent } from "@wowts/ace_event-3.0";
+import { OptionUiGroup } from "../ui/acegui-helpers";
 import { OvaleEquipmentClass, inventorySlotNames } from "./Equipment";
 
 export class Runeforge {

--- a/src/states/runeforge.ts
+++ b/src/states/runeforge.ts
@@ -4,7 +4,7 @@ import {
     ipairs,
     kpairs,
     lualength,
-    pairs,
+    tonumber,
     unpack,
     wipe,
 } from "@wowts/lua";
@@ -25,6 +25,7 @@ import { OvaleEquipmentClass, inventorySlotNames } from "./Equipment";
 export class Runeforge {
     private module: AceModule & AceEvent;
     private equippedLegendaryById: LuaArray<boolean> = {};
+    private equippedRuneforgeById: LuaArray<boolean> = {};
 
     private debugRuneforges: OptionUiGroup = {
         type: "group",
@@ -39,12 +40,17 @@ export class Runeforge {
                     const ids =
                         C_LegendaryCrafting.GetRuneforgePowers(undefined);
                     const output: LuaArray<string> = {};
-                    for (const [, v] of ipairs(ids)) {
+                    for (const [, id] of ipairs(ids)) {
                         const runeforgePower =
-                            C_LegendaryCrafting.GetRuneforgePowerInfo(v);
-                        if (runeforgePower) {
-                            insert(output, `${v}: ${runeforgePower.name}`);
+                            C_LegendaryCrafting.GetRuneforgePowerInfo(id);
+                        if (runeforgePower != undefined) {
+                            insert(output, `${id}: ${runeforgePower.name}`);
                         }
+                    }
+                    insert(output, "");
+                    insert(output, "Equipped:");
+                    for (const [id] of kpairs(this.equippedRuneforgeById)) {
+                        insert(output, `    ${id}`);
                     }
                     return concat(output, "\n");
                 },
@@ -64,7 +70,7 @@ export class Runeforge {
                 get: () => {
                     const output: LuaArray<string> = {};
                     insert(output, "Legendary bonus IDs:");
-                    for (const [id] of pairs(this.equippedLegendaryById)) {
+                    for (const [id] of kpairs(this.equippedLegendaryById)) {
                         insert(output, `    ${id}`);
                     }
                     return concat(output, "\n");
@@ -102,6 +108,7 @@ export class Runeforge {
 
     private handleOvaleEquipmentChanged = (event: string) => {
         wipe(this.equippedLegendaryById);
+        wipe(this.equippedRuneforgeById);
         for (const [slot] of kpairs(inventorySlotNames)) {
             // Update bonus IDs list in equippedLegendaryById.
             const quality = this.equipment.getEquippedItemQuality(slot);
@@ -111,6 +118,18 @@ export class Runeforge {
                 if (lualength(bonusIds) > 0) {
                     const id = bonusIds[1];
                     this.equippedLegendaryById[id] = true;
+                }
+            }
+            // Update power IDs list in equippedRuneforgeById.
+            const location = this.equipment.getEquippedItemLocation(slot);
+            if (location != undefined) {
+                if (C_LegendaryCrafting.IsRuneforgeLegendary(location)) {
+                    const componentInfo =
+                        C_LegendaryCrafting.GetRuneforgeLegendaryComponentInfo(
+                            location
+                        );
+                    const id = tonumber(componentInfo.powerID);
+                    this.equippedRuneforgeById[id] = true;
                 }
             }
         }
@@ -131,6 +150,11 @@ export class Runeforge {
             oneTimeMessage(`${id} is not defined in EquippedRuneforge`);
             return [];
         }
-        return returnBoolean(this.equippedLegendaryById[id]);
+        /* Check both lists and return true if the ID is in either of them.
+         * Technically could be incorrect, but chance of collision is very low.
+         */
+        return returnBoolean(
+            this.equippedLegendaryById[id] || this.equippedRuneforgeById[id]
+        );
     };
 }


### PR DESCRIPTION
Instead of using legendary bonus IDs in scripts, allow using the runeforge power IDs to identify equipped runeforge powers.  The `EquippedRuneforge()` script condition checks that the given id is either a legendary bonus ID or a runeforge power ID.

A future update should probably remove the use of legendary bonus IDs. They are fragile and not necessarily computed correctly because we have to make the assumption that the first bonus ID on a piece of equipment is the legendary bonus ID, and this is not documented anywhere and will probably break in a future patch.  The runeforge power ID is always correct and we query it using the documented API.

The default scripts should be changed to use runeforge power IDs instead of the legendary bonus IDs, but that's an `importsimc` issue that I won't touch for now.