### PR TITLE
refactor: remove snapshots

### DIFF
--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -144,8 +144,7 @@ export class IoC {
             this.equipment,
             this.ovale,
             this.debug,
-            this.profiler,
-            this.lastSpell
+            this.profiler
         );
         this.guid = new Guids(this.ovale, this.debug, this.condition);
         this.spellBook = new OvaleSpellBookClass(

--- a/src/states/Aura.ts
+++ b/src/states/Aura.ts
@@ -942,50 +942,17 @@ export class OvaleAuraClass
                     const spellName =
                         this.ovaleSpellBook.getSpellName(spellId) ||
                         "Unknown spell";
-                    let keepSnapshot = false;
-                    const si = this.ovaleData.spellInfo[spellId];
-                    if (si && si.aura) {
-                        const auraTable =
-                            (this.ovaleGuid.isPlayerPet(guid) && si.aura.pet) ||
-                            si.aura.target;
-                        if (auraTable && auraTable[filter]) {
-                            const spellData = auraTable[filter][auraId];
-                            if (
-                                spellData &&
-                                spellData.cachedParams.named
-                                    .refresh_keep_snapshot &&
-                                (spellData.cachedParams.named.enabled ===
-                                    undefined ||
-                                    spellData.cachedParams.named.enabled)
-                            ) {
-                                keepSnapshot = true;
-                            }
-                        }
-                    }
-                    if (keepSnapshot) {
-                        this.debug.debug(
-                            "    Keeping snapshot stats for %s %s (%d) on %s refreshed by %s (%d), aura.serial=%d",
-                            filter,
-                            name,
-                            auraId,
-                            guid,
-                            spellName,
-                            spellId,
-                            aura.serial
-                        );
-                    } else {
-                        this.debug.debug(
-                            "    Snapshot stats for %s %s (%d) on %s applied by %s (%d), aura.serial=%d",
-                            filter,
-                            name,
-                            auraId,
-                            guid,
-                            spellName,
-                            spellId,
-                            aura.serial
-                        );
-                        this.lastSpell.copySpellcastInfo(spellcast, aura);
-                    }
+                    this.debug.debug(
+                        "    Snapshot stats for %s %s (%d) on %s applied by %s (%d), aura.serial=%d",
+                        filter,
+                        name,
+                        auraId,
+                        guid,
+                        spellName,
+                        spellId,
+                        aura.serial
+                    );
+                    this.lastSpell.copySpellcastInfo(spellcast, aura);
                 }
                 const si = this.ovaleData.spellInfo[auraId];
                 if (si) {
@@ -1917,7 +1884,6 @@ export class OvaleAuraClass
                 let extend = 0;
                 let toggle = undefined;
                 let refresh = false;
-                let keepSnapshot = false;
                 const data = this.ovaleData.checkSpellAuraData(
                     auraId,
                     spellData,
@@ -1926,9 +1892,6 @@ export class OvaleAuraClass
                 );
                 if (data.refresh) {
                     refresh = true;
-                } else if (data.refresh_keep_snapshot) {
-                    refresh = true;
-                    keepSnapshot = true;
                 } else if (data.toggle) {
                     toggle = true;
                 } else if (isNumber(data.set)) {
@@ -2043,12 +2006,7 @@ export class OvaleAuraClass
                                 aura.duration,
                                 aura.ending
                             );
-                            if (keepSnapshot) {
-                                this.debug.log(
-                                    "Aura %d keeping previous snapshot.",
-                                    auraId
-                                );
-                            } else if (spellcast) {
+                            if (spellcast) {
                                 this.lastSpell.copySpellcastInfo(
                                     spellcast,
                                     aura

--- a/src/states/Aura.ts
+++ b/src/states/Aura.ts
@@ -56,9 +56,6 @@ import { OvaleOptionsClass } from "../ui/Options";
 import { AceModule } from "@wowts/tsaddon";
 import { OptionUiAll } from "../ui/acegui-helpers";
 
-const strlower = lower;
-const tconcat = concat;
-
 let playerGUID = "fake_guid";
 let petGUIDs: LuaObj<number> = {};
 const pool = new OvalePool<Aura | LuaObj<Aura> | LuaObj<LuaObj<Aura>>>(
@@ -84,7 +81,7 @@ export const spellInfoDebuffTypes: LuaObj<string> = {};
 
 {
     for (const [debuffType] of pairs(debuffTypes)) {
-        const siDebuffType = strlower(debuffType);
+        const siDebuffType = lower(debuffType);
         spellInfoDebuffTypes[siDebuffType] = debuffType;
     }
 }
@@ -435,7 +432,7 @@ export class OvaleAuraClass
                                 output[lualength(output) + 1] = "== DEBUFFS ==";
                                 output[lualength(output) + 1] = harmful;
                             }
-                            return tconcat(output, "\n");
+                            return concat(output, "\n");
                         },
                     },
                 },
@@ -470,7 +467,7 @@ export class OvaleAuraClass
                                 output[lualength(output) + 1] = "== DEBUFFS ==";
                                 output[lualength(output) + 1] = harmful;
                             }
-                            return tconcat(output, "\n");
+                            return concat(output, "\n");
                         },
                     },
                 },

--- a/src/states/Aura.ts
+++ b/src/states/Aura.ts
@@ -135,7 +135,6 @@ export interface Aura extends SpellCast {
     consumed: boolean;
     icon: string | undefined;
     stealable: boolean;
-    snapshotTime: number;
     cooldownEnding: number;
     combopoints?: number;
     damageMultiplier?: number;
@@ -329,7 +328,8 @@ let startFirst: number, endingLast: number;
 
 export class OvaleAuraClass
     extends States<AuraInterface>
-    implements StateModule {
+    implements StateModule
+{
     private debug: Tracer;
     private module: AceModule & AceEvent;
     private profiler: Profiler;
@@ -964,28 +964,24 @@ export class OvaleAuraClass
                     }
                     if (keepSnapshot) {
                         this.debug.debug(
-                            "    Keeping snapshot stats for %s %s (%d) on %s refreshed by %s (%d) from %f, now=%f, aura.serial=%d",
+                            "    Keeping snapshot stats for %s %s (%d) on %s refreshed by %s (%d), aura.serial=%d",
                             filter,
                             name,
                             auraId,
                             guid,
                             spellName,
                             spellId,
-                            aura.snapshotTime,
-                            atTime,
                             aura.serial
                         );
                     } else {
                         this.debug.debug(
-                            "    Snapshot stats for %s %s (%d) on %s applied by %s (%d) from %f, now=%f, aura.serial=%d",
+                            "    Snapshot stats for %s %s (%d) on %s applied by %s (%d), aura.serial=%d",
                             filter,
                             name,
                             auraId,
                             guid,
                             spellName,
                             spellId,
-                            spellcast.snapshotTime,
-                            atTime,
                             aura.serial
                         );
                         this.lastSpell.copySpellcastInfo(spellcast, aura);

--- a/src/states/Cooldown.ts
+++ b/src/states/Cooldown.ts
@@ -91,7 +91,8 @@ export class CooldownData {
 
 export class OvaleCooldownClass
     extends States<CooldownData>
-    implements SpellCastModule, StateModule {
+    implements SpellCastModule, StateModule
+{
     serial = 0;
     sharedCooldown: LuaObj<LuaArray<boolean>> = {};
     gcd = {
@@ -262,12 +263,14 @@ export class OvaleCooldownClass
         }
         return [gcd, haste];
     }
+
     copySpellcastInfo = (spellcast: SpellCast, dest: SpellCast) => {
         if (spellcast.offgcd) {
             dest.offgcd = spellcast.offgcd;
         }
     };
-    saveSpellcastInfo = (spellcast: SpellCast) => {
+
+    saveSpellcastInfo = (spellcast: SpellCast, atTime: number) => {
         const spellId = spellcast.spellId;
         if (spellId) {
             const gcd = this.ovaleData.getSpellInfoProperty(
@@ -321,12 +324,8 @@ export class OvaleCooldownClass
             cd.duration = duration;
             cd.enable = enable;
             if (isNumber(spellId)) {
-                const [
-                    charges,
-                    maxCharges,
-                    chargeStart,
-                    chargeDuration,
-                ] = GetSpellCharges(spellId);
+                const [charges, maxCharges, chargeStart, chargeDuration] =
+                    GetSpellCharges(spellId);
                 if (charges) {
                     cd.charges = charges;
                     cd.maxCharges = maxCharges;
@@ -408,9 +407,8 @@ export class OvaleCooldownClass
                     targetGUID
                 );
                 if (haste) {
-                    const multiplier = this.ovalePaperDoll.getBaseHasteMultiplier(
-                        this.ovalePaperDoll.next
-                    );
+                    const multiplier =
+                        this.ovalePaperDoll.getBaseHasteMultiplier(atTime);
                     duration = duration / multiplier;
                 }
             }

--- a/src/states/Future.ts
+++ b/src/states/Future.ts
@@ -154,7 +154,8 @@ export class OvaleFutureData {
 
 export class OvaleFutureClass
     extends States<OvaleFutureData>
-    implements StateModule {
+    implements StateModule
+{
     private module: AceModule & AceEvent;
     private tracer: Tracer;
     private profiler: Profiler;
@@ -796,9 +797,8 @@ export class OvaleFutureClass
             const now = GetTime();
             const [spellcast] = this.getSpellcast(spell, spellId, lineId, now);
             if (spellcast) {
-                let [name, , , startTime, endTime, , castId] = UnitCastingInfo(
-                    unitId
-                );
+                let [name, , , startTime, endTime, , castId] =
+                    UnitCastingInfo(unitId);
                 if (lineId == castId && name == spell) {
                     startTime = startTime / 1000;
                     endTime = endTime / 1000;
@@ -858,9 +858,8 @@ export class OvaleFutureClass
             );
         } else {
             spellcast.targetName = targetName;
-            let [targetGUID, nextGUID] = this.ovaleGuid.getGuidByName(
-                targetName
-            );
+            let [targetGUID, nextGUID] =
+                this.ovaleGuid.getGuidByName(targetName);
             if (nextGUID) {
                 let name = this.ovaleGuid.getUnitName("target");
                 if (name == targetName) {
@@ -963,9 +962,8 @@ export class OvaleFutureClass
                     undefined
                 );
             }
-            let [name, , , startTime, endTime, , castId] = UnitCastingInfo(
-                unitId
-            );
+            let [name, , , startTime, endTime, , castId] =
+                UnitCastingInfo(unitId);
             if (lineId == castId && name == spellName) {
                 startTime = startTime / 1000;
                 endTime = endTime / 1000;
@@ -1479,7 +1477,8 @@ export class OvaleFutureClass
                     (<any>this.current.lastOffGCDSpellcast)[k] = v;
                 }
                 this.lastSpell.lastSpellcast = this.current.lastOffGCDSpellcast;
-                this.next.lastOffGCDSpellcast = this.current.lastOffGCDSpellcast;
+                this.next.lastOffGCDSpellcast =
+                    this.current.lastOffGCDSpellcast;
             } else {
                 this.tracer.debug(
                     "    Caching spell %s (%d) as most recent GCD spellcast.",
@@ -1490,19 +1489,15 @@ export class OvaleFutureClass
                     (<any>this.lastSpell.lastGCDSpellcast)[k] = v;
                 }
                 this.lastSpell.lastSpellcast = this.lastSpell.lastGCDSpellcast;
-                this.next.lastGCDSpellId = this.lastSpell.lastGCDSpellcast.spellId;
+                this.next.lastGCDSpellId =
+                    this.lastSpell.lastGCDSpellcast.spellId;
             }
         }
         this.profiler.stopProfiling("OvaleFuture_UpdateLastSpellcast");
     }
 
     updateSpellcastSnapshot(spellcast: SpellCast, atTime: number) {
-        if (
-            spellcast.queued &&
-            (!spellcast.snapshotTime ||
-                (spellcast.snapshotTime < atTime &&
-                    atTime < spellcast.stop + 1))
-        ) {
+        if (spellcast.queued) {
             if (spellcast.targetName) {
                 this.tracer.debug(
                     "    Updating to snapshot from %s for spell %s to %s (%s) queued at %s.",

--- a/src/states/Future.ts
+++ b/src/states/Future.ts
@@ -49,8 +49,6 @@ import {
 } from "../engine/condition";
 import { Runner } from "../engine/runner";
 
-const strsub = sub;
-const tremove = remove;
 let timeAuraAdded: undefined | number = undefined;
 
 // let SIMULATOR_LAG = 0.005;
@@ -362,7 +360,7 @@ export class OvaleFutureClass
             if (spellCastEvents[cleuEvent]) {
                 const now = GetTime();
                 if (
-                    strsub(cleuEvent, 1, 11) == "SPELL_CAST_" &&
+                    sub(cleuEvent, 1, 11) == "SPELL_CAST_" &&
                     destName &&
                     destName != ""
                 ) {
@@ -591,7 +589,7 @@ export class OvaleFutureClass
                 spellId,
                 delta
             );
-            tremove(this.lastSpell.queue, i);
+            remove(this.lastSpell.queue, i);
             lastSpellCastPool.release(spellcast);
             this.ovale.needRefresh();
             this.module.SendMessage(
@@ -710,7 +708,7 @@ export class OvaleFutureClass
                 spellcast.stop = now;
                 this.updateLastSpellcast(now, spellcast);
                 const targetGUID = spellcast.target;
-                tremove(this.lastSpell.queue, index);
+                remove(this.lastSpell.queue, index);
                 lastSpellCastPool.release(spellcast);
                 this.ovale.needRefresh();
                 this.module.SendMessage(
@@ -1127,7 +1125,7 @@ export class OvaleFutureClass
                         finish = "hit";
                     }
                     if (finished) {
-                        tremove(this.lastSpell.queue, index);
+                        remove(this.lastSpell.queue, index);
                         lastSpellCastPool.release(spellcast);
                         this.ovale.needRefresh();
                         this.module.SendMessage(
@@ -1252,7 +1250,7 @@ export class OvaleFutureClass
                     this.tracer.debug(
                         "Remove spell from queue because there was no success before"
                     );
-                    tremove(this.lastSpell.queue, index);
+                    remove(this.lastSpell.queue, index);
                     lastSpellCastPool.release(spellcast);
                     this.ovale.needRefresh();
                 }

--- a/src/states/LastSpell.ts
+++ b/src/states/LastSpell.ts
@@ -41,8 +41,6 @@ export function createSpellCast(): SpellCast {
 }
 
 export interface PaperDollSnapshot extends Powers {
-    snapshotTime?: number;
-
     strength?: number;
     agility?: number;
     intellect?: number;

--- a/src/states/LastSpell.ts
+++ b/src/states/LastSpell.ts
@@ -3,7 +3,7 @@ import { lualength, LuaObj, LuaArray, pairs } from "@wowts/lua";
 import { remove, insert } from "@wowts/table";
 import { Powers } from "./Power";
 
-export interface SpellCast extends PaperDollSnapshot {
+export interface SpellCast extends Powers {
     stop: number;
     start: number;
     lineId?: string;
@@ -20,7 +20,6 @@ export interface SpellCast extends PaperDollSnapshot {
     castByPlayer?: boolean;
     offgcd?: boolean;
     damageMultiplier?: number;
-    combopoints?: number;
 }
 
 export function createSpellCast(): SpellCast {
@@ -29,59 +28,15 @@ export function createSpellCast(): SpellCast {
         stop: 0,
         start: 0,
         queued: 0,
-        hastePercent: 0,
-        meleeAttackSpeedPercent: 0,
-        rangedAttackSpeedPercent: 0,
-        spellCastSpeedPercent: 0,
-        masteryEffect: 0,
         target: "unknown",
         targetName: "target",
         spellName: "Unknown spell",
     };
 }
 
-export interface PaperDollSnapshot extends Powers {
-    strength?: number;
-    agility?: number;
-    intellect?: number;
-    stamina?: number;
-    // spirit?: number;
-
-    attackPower?: number;
-    spellPower?: number;
-    //rangedAttackPower?: number;
-    //spellBonusDamage?: number;
-    //spellBonusHealing?: number;
-
-    critRating?: number;
-    meleeCrit?: number;
-    rangedCrit?: number;
-    spellCrit?: number;
-
-    hasteRating?: number;
-    hastePercent: number;
-    meleeAttackSpeedPercent: number;
-    rangedAttackSpeedPercent: number;
-    spellCastSpeedPercent: number;
-
-    masteryRating?: number;
-    masteryEffect: number;
-
-    versatilityRating?: number;
-    versatility?: number;
-
-    mainHandWeaponDPS?: number;
-    offHandWeaponDPS?: number;
-    baseDamageMultiplier?: number;
-}
-
 export interface SpellCastModule {
     copySpellcastInfo: (spellcast: SpellCast, dest: SpellCast) => void;
-    saveSpellcastInfo: (
-        spellcast: SpellCast,
-        atTime: number,
-        future?: PaperDollSnapshot
-    ) => void;
+    saveSpellcastInfo: (spellcast: SpellCast, atTime: number) => void;
 }
 
 export const lastSpellCastPool = new OvalePool<SpellCast>("OvaleFuture_pool");
@@ -112,14 +67,19 @@ export class LastSpell {
         }
         return spellcast;
     }
+
     copySpellcastInfo(spellcast: SpellCast, dest: SpellCast) {
-        if (spellcast.damageMultiplier) {
-            dest.damageMultiplier = spellcast.damageMultiplier;
-        }
         for (const [, mod] of pairs(this.modules)) {
-            const func = mod.copySpellcastInfo;
-            if (func) {
-                func(spellcast, dest);
+            if (mod.copySpellcastInfo) {
+                mod.copySpellcastInfo(spellcast, dest);
+            }
+        }
+    }
+
+    saveSpellcastInfo(spellcast: SpellCast, atTime: number) {
+        for (const [, mod] of pairs(this.modules)) {
+            if (mod.saveSpellcastInfo) {
+                mod.saveSpellcastInfo(spellcast, atTime);
             }
         }
     }
@@ -127,6 +87,7 @@ export class LastSpell {
     registerSpellcastInfo(mod: SpellCastModule) {
         insert(this.modules, mod);
     }
+
     unregisterSpellcastInfo(mod: SpellCastModule) {
         for (let i = lualength(this.modules); i >= 1; i += -1) {
             if (this.modules[i] == mod) {

--- a/src/states/PaperDoll.ts
+++ b/src/states/PaperDoll.ts
@@ -24,7 +24,6 @@ import {
     GetSpecialization,
     GetSpellBonusDamage,
     GetSpellCritChance,
-    GetTime,
     UnitAttackPower,
     UnitDamage,
     UnitRangedDamage,
@@ -162,8 +161,6 @@ export const ovaleSpecializationName: {
 };
 
 export class PaperDollData implements PaperDollSnapshot {
-    snapshotTime = 0;
-
     strength = 0;
     agility = 0;
     stamina = 0;
@@ -199,39 +196,37 @@ export class PaperDollData implements PaperDollSnapshot {
 }
 
 const statName: LuaArray<keyof PaperDollSnapshot> = {
-    [1]: "snapshotTime",
-    [2]: "strength",
-    [3]: "agility",
-    [4]: "stamina",
-    [5]: "intellect",
-    [6]: "attackPower",
-    [7]: "spellPower",
-    [8]: "critRating",
-    [9]: "meleeCrit",
-    [10]: "rangedCrit",
-    [11]: "spellCrit",
-    [12]: "hasteRating",
-    [13]: "hastePercent",
-    [14]: "meleeAttackSpeedPercent",
-    [15]: "rangedAttackSpeedPercent",
-    [16]: "spellCastSpeedPercent",
-    [17]: "masteryRating",
-    [18]: "masteryEffect",
-    [19]: "versatilityRating",
-    [20]: "versatility",
-    [21]: "mainHandWeaponDPS",
-    [22]: "offHandWeaponDPS",
-    [23]: "baseDamageMultiplier",
+    [1]: "strength",
+    [2]: "agility",
+    [3]: "stamina",
+    [4]: "intellect",
+    [5]: "attackPower",
+    [6]: "spellPower",
+    [7]: "critRating",
+    [8]: "meleeCrit",
+    [9]: "rangedCrit",
+    [10]: "spellCrit",
+    [11]: "hasteRating",
+    [12]: "hastePercent",
+    [13]: "meleeAttackSpeedPercent",
+    [14]: "rangedAttackSpeedPercent",
+    [15]: "spellCastSpeedPercent",
+    [16]: "masteryRating",
+    [17]: "masteryEffect",
+    [18]: "versatilityRating",
+    [19]: "versatility",
+    [20]: "mainHandWeaponDPS",
+    [21]: "offHandWeaponDPS",
+    [22]: "baseDamageMultiplier",
 };
 const snapshotStatName: LuaArray<keyof PaperDollSnapshot> = {
-    [1]: "snapshotTime",
-    [2]: "masteryEffect",
-    [3]: "baseDamageMultiplier",
+    [1]: "baseDamageMultiplier",
 };
 
 export class OvalePaperDollClass
     extends States<PaperDollSnapshot>
-    implements SpellCastModule, StateModule {
+    implements SpellCastModule, StateModule
+{
     class: ClassId;
     level = UnitLevel("player");
     specialization: SpecializationIndex | undefined = undefined;
@@ -358,7 +353,6 @@ export class OvalePaperDollClass
             this.current.stamina = UnitStat(unitId, 3);
             this.current.intellect = UnitStat(unitId, 4);
             // this.current.spirit = 0;
-            this.current.snapshotTime = GetTime();
             this.ovale.needRefresh();
             this.profiler.stopProfiling("OvalePaperDoll_UpdateStats");
         }
@@ -386,7 +380,6 @@ export class OvalePaperDollClass
             CR_VERSATILITY_DAMAGE_DONE
         );
 
-        this.current.snapshotTime = GetTime();
         this.ovale.needRefresh();
         this.profiler.stopProfiling("OvalePaperDoll_UpdateStats");
     };
@@ -399,7 +392,6 @@ export class OvalePaperDollClass
             this.current.masteryEffect = GetMasteryEffect();
             this.ovale.needRefresh();
         }
-        this.current.snapshotTime = GetTime();
         this.profiler.stopProfiling("OvalePaperDoll_UpdateStats");
     };
     private handleUnitAttackPower = (event: string, unitId: string) => {
@@ -407,7 +399,6 @@ export class OvalePaperDollClass
             this.profiler.startProfiling("OvalePaperDoll_UpdateStats");
             const [base, posBuff, negBuff] = UnitAttackPower(unitId);
             this.current.attackPower = base + posBuff + negBuff;
-            this.current.snapshotTime = GetTime();
             this.ovale.needRefresh();
             this.handleUpdateDamage();
             this.profiler.stopProfiling("OvalePaperDoll_UpdateStats");
@@ -419,7 +410,6 @@ export class OvalePaperDollClass
             const [base, posBuff, negBuff] = UnitRangedAttackPower(unitId);
             this.ovale.needRefresh();
             this.current.attackPower = base + posBuff + negBuff;
-            this.current.snapshotTime = GetTime();
             this.profiler.stopProfiling("OvalePaperDoll_UpdateStats");
         }
     };
@@ -428,14 +418,12 @@ export class OvalePaperDollClass
         this.current.spellPower = GetSpellBonusDamage(
             spellDamageSchools[this.class]
         );
-        this.current.snapshotTime = GetTime();
         this.ovale.needRefresh();
         this.profiler.stopProfiling("OvalePaperDoll_UpdateStats");
     };
     private handlePlayerLevelUp = (event: string, level: string) => {
         this.profiler.startProfiling("OvalePaperDoll_UpdateStats");
         this.level = tonumber(level) || UnitLevel("player");
-        this.current.snapshotTime = GetTime();
         this.ovale.needRefresh();
         this.debug.debugTimestamp("%s: level = %d", event, this.level);
         this.profiler.stopProfiling("OvalePaperDoll_UpdateStats");
@@ -446,7 +434,6 @@ export class OvalePaperDollClass
             this.profiler.startProfiling("OvalePaperDoll_UpdateStats");
             this.level = UnitLevel(unitId);
             this.debug.debugTimestamp("%s: level = %d", event, this.level);
-            this.current.snapshotTime = GetTime();
             this.profiler.stopProfiling("OvalePaperDoll_UpdateStats");
         }
     };
@@ -459,7 +446,6 @@ export class OvalePaperDollClass
         this.current.baseDamageMultiplier = damageMultiplier || 1;
         this.current.mainHandWeaponDPS = this.ovaleEquipement.mainHandDPS || 0;
         this.current.offHandWeaponDPS = this.ovaleEquipement.offHandDPS || 0;
-        this.current.snapshotTime = GetTime();
         this.ovale.needRefresh();
         this.profiler.stopProfiling("OvalePaperDoll_UpdateDamage");
     };
@@ -469,7 +455,6 @@ export class OvalePaperDollClass
         if (this.specialization != newSpecialization) {
             const oldSpecialization = this.specialization;
             this.specialization = newSpecialization;
-            this.current.snapshotTime = GetTime();
             this.ovale.needRefresh();
             this.module.SendMessage(
                 "Ovale_SpecializationChanged",
@@ -572,7 +557,6 @@ export class OvalePaperDollClass
         // this.next.class = undefined;
         // this.level = undefined;
         // this.specialization = undefined;
-        this.next.snapshotTime = 0;
 
         this.next.strength = 0;
         this.next.agility = 0;

--- a/src/states/Power.ts
+++ b/src/states/Power.ts
@@ -28,8 +28,6 @@ import { OvaleSpellBookClass } from "./SpellBook";
 import { OvaleCombatClass } from "./combat";
 import { OptionUiAll } from "../ui/acegui-helpers";
 
-const strlower = lower;
-
 interface PowerInfo {
     id: number;
     token: string;
@@ -230,7 +228,7 @@ export class OvalePowerClass extends States<PowerState> implements StateModule {
         };
 
         for (const [powerType, powerId] of pairs(Enum.PowerType)) {
-            const powerTypeLower = <PowerType>strlower(powerType);
+            const powerTypeLower = <PowerType>lower(powerType);
             const powerToken =
                 this.ovale.playerClass != undefined &&
                 possiblePowerTypes[this.ovale.playerClass][powerTypeLower];

--- a/src/states/Power.ts
+++ b/src/states/Power.ts
@@ -30,11 +30,6 @@ import { OptionUiAll } from "../ui/acegui-helpers";
 
 const strlower = lower;
 
-const spellcastInfoPowerTypes: LuaArray<PowerType> = {
-    1: "chi",
-    2: "holypower",
-};
-
 interface PowerInfo {
     id: number;
     token: string;
@@ -478,13 +473,6 @@ export class OvalePowerClass extends States<PowerState> implements StateModule {
         }
         return concat(array, "\n");
     }
-    copySpellcastInfo = (mod: this, spellcast: SpellCast, dest: SpellCast) => {
-        for (const [, powerType] of pairs(spellcastInfoPowerTypes)) {
-            if (spellcast[powerType]) {
-                dest[powerType] = spellcast[powerType];
-            }
-        }
-    };
 
     initializeState() {
         for (const [powerType] of kpairs(this.powerInfos)) {

--- a/src/states/Runes.ts
+++ b/src/states/Runes.ts
@@ -5,7 +5,7 @@ import { ipairs, LuaArray, wipe } from "@wowts/lua";
 import { GetRuneCooldown, GetTime } from "@wowts/wow-mock";
 import { huge } from "@wowts/math";
 import { sort } from "@wowts/table";
-import { SpellCast, PaperDollSnapshot } from "./LastSpell";
+import { SpellCast } from "./LastSpell";
 import { AceModule } from "@wowts/tsaddon";
 import { Tracer, DebugTools } from "../engine/debug";
 import { Profiler, OvaleProfilerClass } from "../engine/profiler";
@@ -207,7 +207,7 @@ export class OvaleRunesClass extends States<RuneData> implements StateModule {
         if (si) {
             let count = si.runes || 0;
             while (count > 0) {
-                this.consumeRune(spellId, atTime, spellcast);
+                this.consumeRune(spellId, atTime);
                 count = count - 1;
             }
         }
@@ -219,7 +219,7 @@ export class OvaleRunesClass extends States<RuneData> implements StateModule {
         }
         rune.endCooldown = atTime;
     }
-    consumeRune(spellId: number, atTime: number, snapshot: PaperDollSnapshot) {
+    consumeRune(spellId: number, atTime: number) {
         this.profiler.startProfiling("OvaleRunes_state_ConsumeRune");
         let consumedRune: Rune | undefined;
         for (let slot = 1; slot <= runeSlots; slot += 1) {
@@ -239,9 +239,7 @@ export class OvaleRunesClass extends States<RuneData> implements StateModule {
             }
             const duration =
                 10 /
-                this.ovalePaperDoll.getSpellCastSpeedPercentMultiplier(
-                    snapshot
-                );
+                this.ovalePaperDoll.getSpellCastSpeedPercentMultiplier(atTime);
             consumedRune.startCooldown = start;
             consumedRune.endCooldown = start + duration;
             const runicpower =

--- a/src/states/Warlock.ts
+++ b/src/states/Warlock.ts
@@ -135,20 +135,8 @@ export class OvaleWarlockClass implements StateModule {
         event: string,
         ...parameters: any[]
     ) => {
-        const [
-            ,
-            cleuEvent,
-            ,
-            sourceGUID,
-            ,
-            ,
-            ,
-            destGUID,
-            ,
-            ,
-            ,
-            spellId,
-        ] = CombatLogGetCurrentEventInfo();
+        const [, cleuEvent, , sourceGUID, , , , destGUID, , , , spellId] =
+            CombatLogGetCurrentEventInfo();
         if (sourceGUID != this.ovale.playerGUID) {
             return;
         }
@@ -310,20 +298,16 @@ export class OvaleWarlockClass implements StateModule {
      * Based on SimulationCraft function time_to_shard
      * Seeks to return the average expected time for the player to generate a single soul shard.
      */
-    private getTimeToShard(now: number) {
+    private getTimeToShard(atTime: number) {
         let value = 3600;
         const tickTime =
-            2 /
-            this.ovalePaperDoll.getHasteMultiplier(
-                "spell",
-                this.ovalePaperDoll.next
-            );
+            2 / this.ovalePaperDoll.getHasteMultiplier("spell", atTime);
         const [activeAgonies] = this.ovaleAura.auraCount(
             SpellId.agony,
             "HARMFUL",
             true,
             undefined,
-            now,
+            atTime,
             undefined
         );
         if (activeAgonies > 0) {

--- a/src/states/conditions.ts
+++ b/src/states/conditions.ts
@@ -339,23 +339,9 @@ export class OvaleConditions {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const auraId = positionalParams[1];
-        const [target, filter, mine] = this.parseCondition(
-            positionalParams,
-            namedParams
-        );
-        const aura = this.auras.getAura(target, auraId, atTime, filter, mine);
-        if (aura && this.auras.isActiveAura(aura, atTime)) {
-            const value = (aura && aura.combopoints) || 0;
-            return returnValueBetween(
-                aura.gain,
-                aura.ending,
-                value,
-                aura.start,
-                0
-            );
-        }
-        return returnConstant(0);
+        const combopoints = 0;
+        oneTimeMessage("Warning: 'BuffComboPoints()' is not implemented.");
+        return returnConstant(combopoints);
     };
 
     /** Get the number of seconds before a buff can be gained again.

--- a/src/states/conditions.ts
+++ b/src/states/conditions.ts
@@ -152,12 +152,13 @@ export class OvaleConditions {
     }
 
     /** Return the time in seconds, adjusted by the named haste effect. */
-    getHastedTime(seconds: number, haste: HasteType | undefined) {
+    getHastedTime(
+        seconds: number,
+        haste: HasteType | undefined,
+        atTime?: number
+    ) {
         seconds = seconds || 0;
-        const multiplier = this.paperDoll.getHasteMultiplier(
-            haste,
-            this.paperDoll.next
-        );
+        const multiplier = this.paperDoll.getHasteMultiplier(haste, atTime);
         return seconds / multiplier;
     }
 
@@ -260,23 +261,13 @@ export class OvaleConditions {
         if (this.data.buffSpellList[auraId]) {
             const spellList = this.data.buffSpellList[auraId];
             for (const [id] of pairs(spellList)) {
-                value = this.auras.getBaseDuration(
-                    id,
-                    undefined,
-                    atTime,
-                    this.paperDoll.next
-                );
+                value = this.auras.getBaseDuration(id, undefined, atTime);
                 if (value != INFINITY) {
                     break;
                 }
             }
         } else {
-            value = this.auras.getBaseDuration(
-                auraId,
-                undefined,
-                atTime,
-                this.paperDoll.next
-            );
+            value = this.auras.getBaseDuration(auraId, undefined, atTime);
         }
         return returnConstant(value);
     };
@@ -631,7 +622,8 @@ export class OvaleConditions {
             const [gain, , ending] = [aura.gain, aura.start, aura.ending];
             const hastedSeconds = this.getHastedTime(
                 seconds,
-                namedParams.haste as HasteType
+                namedParams.haste as HasteType,
+                atTime
             );
             if (ending - hastedSeconds <= gain) {
                 return [gain, INFINITY];
@@ -677,7 +669,7 @@ export class OvaleConditions {
         const aura = this.auras.getAura(target, auraId, atTime, filter, mine);
         if (aura) {
             const [gain, , ending] = [aura.gain, aura.start, aura.ending];
-            seconds = this.getHastedTime(seconds, haste);
+            seconds = this.getHastedTime(seconds, haste, atTime);
             if (ending - seconds <= gain) {
                 return [];
             } else {
@@ -918,20 +910,15 @@ export class OvaleConditions {
         const excludeUnitId =
             (namedParams.excludeTarget == 1 && this.baseState.defaultTarget) ||
             undefined;
-        const [
-            count,
-            stacks,
-            ,
-            endingChangeCount,
-            startFirst,
-        ] = this.auras.auraCount(
-            auraId,
-            filter,
-            mine,
-            1,
-            atTime,
-            excludeUnitId
-        );
+        const [count, stacks, , endingChangeCount, startFirst] =
+            this.auras.auraCount(
+                auraId,
+                filter,
+                mine,
+                1,
+                atTime,
+                excludeUnitId
+            );
         if (count > 0) {
             return returnValueBetween(
                 startFirst,
@@ -1473,9 +1460,8 @@ export class OvaleConditions {
         const interval = positionalParams[1];
         let value = 0;
         if (interval > 0) {
-            const [total, totalMagic] = this.damageTaken.getRecentDamage(
-                interval
-            );
+            const [total, totalMagic] =
+                this.damageTaken.getRecentDamage(interval);
             value = total - totalMagic;
         }
         return returnConstant(value);
@@ -1633,8 +1619,8 @@ export class OvaleConditions {
     ) => {
         let value = this.enemies.next.enemies;
         if (!value) {
-            let useTagged = this.ovaleOptions.db.profile.apparence
-                .taggedEnemies;
+            let useTagged =
+                this.ovaleOptions.db.profile.apparence.taggedEnemies;
             if (namedParams.tagged == 0) {
                 useTagged = false;
             } else if (namedParams.tagged == 1) {
@@ -3730,9 +3716,8 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [count, startCooldown, endCooldown] = this.runes.runeCount(
-            atTime
-        );
+        const [count, startCooldown, endCooldown] =
+            this.runes.runeCount(atTime);
         if (startCooldown < INFINITY) {
             const rate = 1 / (endCooldown - startCooldown);
             return returnValueBetween(
@@ -3751,9 +3736,8 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [count, startCooldown, endCooldown] = this.runes.runeDeficit(
-            atTime
-        );
+        const [count, startCooldown, endCooldown] =
+            this.runes.runeDeficit(atTime);
         if (startCooldown < INFINITY) {
             const rate = -1 / (endCooldown - startCooldown);
             return returnValueBetween(
@@ -3784,9 +3768,8 @@ l    */
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [count, startCooldown, endCooldown] = this.runes.runeCount(
-            atTime
-        );
+        const [count, startCooldown, endCooldown] =
+            this.runes.runeCount(atTime);
         if (startCooldown < INFINITY) {
             return returnValueBetween(
                 startCooldown,
@@ -4212,12 +4195,8 @@ l    */
         atTime: number
     ) => {
         const spellId = positionalParams[1];
-        const [
-            charges,
-            maxCharges,
-            start,
-            duration,
-        ] = this.cooldown.getSpellCharges(spellId, atTime);
+        const [charges, maxCharges, start, duration] =
+            this.cooldown.getSpellCharges(spellId, atTime);
         if (charges && charges < maxCharges) {
             const ending = start + duration;
             return returnValueBetween(start, ending, duration, start, -1);
@@ -4244,12 +4223,8 @@ l    */
         atTime: number
     ) => {
         const spellId = positionalParams[1];
-        const [
-            charges,
-            maxCharges,
-            start,
-            duration,
-        ] = this.cooldown.getSpellCharges(spellId, atTime);
+        const [charges, maxCharges, start, duration] =
+            this.cooldown.getSpellCharges(spellId, atTime);
         if (namedParams.count == 0 && charges < maxCharges) {
             return returnValueBetween(
                 atTime,
@@ -4275,12 +4250,8 @@ l    */
         atTime: number
     ) => {
         const spellId = positionalParams[1];
-        const [
-            charges,
-            maxCharges,
-            start,
-            chargeDuration,
-        ] = this.cooldown.getSpellCharges(spellId, atTime);
+        const [charges, maxCharges, start, chargeDuration] =
+            this.cooldown.getSpellCharges(spellId, atTime);
         if (charges && charges < maxCharges) {
             const duration = (maxCharges - charges) * chargeDuration;
             const ending = start + duration;
@@ -4725,7 +4696,7 @@ l    */
         if (aura && this.auras.isActiveAura(aura, atTime)) {
             tickTime = aura.tick;
         } else {
-            tickTime = this.auras.getTickLength(auraId, this.paperDoll.next);
+            tickTime = this.auras.getTickLength(auraId, atTime);
         }
         if (tickTime && tickTime > 0) {
             return returnConstant(tickTime);
@@ -4809,9 +4780,7 @@ l    */
         const aura = this.auras.getAura(target, auraId, atTime, filter, mine);
         if (aura && this.auras.isActiveAura(aura, atTime)) {
             const lastTickTime = aura.lastTickTime || aura.start;
-            const tick =
-                aura.tick ||
-                this.auras.getTickLength(auraId, this.paperDoll.next);
+            const tick = aura.tick || this.auras.getTickLength(auraId, atTime);
             const remainingTime = tick - (atTime - lastTickTime);
             if (remainingTime && remainingTime > 0) {
                 return returnValueBetween(
@@ -5093,7 +5062,7 @@ l    */
     ) => {
         const seconds = positionalParams[1];
         const haste = (namedParams.haste as HasteType) || "spell";
-        const value = this.getHastedTime(seconds, haste);
+        const value = this.getHastedTime(seconds, haste, atTime);
         return returnConstant(value);
     };
 


### PR DESCRIPTION
Blizzard removed almost every form of DoT snapshotting since Warlords
of Draenor. This branch removes most of the code associated with
snapshotting from the codebase and does minor cleanups of the modules
touched by the changes.