### PR TITLE
fix: use correct return value for UnitName()

### DIFF
--- a/src/engine/guid.ts
+++ b/src/engine/guid.ts
@@ -239,7 +239,7 @@ export class Guids {
     }
     updateUnit(unitId: string) {
         const guid = UnitGUID(unitId);
-        const name = UnitName(unitId);
+        const [name] = UnitName(unitId);
         const previousGUID = this.unitGUID[unitId];
         const previousName = this.unitName[unitId];
         if (!guid || guid != previousGUID) {
@@ -327,7 +327,12 @@ export class Guids {
     }
     getUnitName(unitId: string) {
         if (unitId) {
-            return this.unitName[unitId] || UnitName(unitId);
+            if (this.unitName[unitId]) {
+                return this.unitName[unitId];
+            } else {
+                const [name] = UnitName(unitId);
+                return name;
+            }
         }
         return undefined;
     }

--- a/src/states/BossMod.ts
+++ b/src/states/BossMod.ts
@@ -107,7 +107,8 @@ export class OvaleBossModClass {
         //     let dep = depth || 1;
         //     isWorldBoss = target != undefined && UnitExists(target) && UnitLevel(target) < 0;
         //     if (isWorldBoss) {
-        //         this.Debug("%s is worldboss (%s)", target, UnitName(target));
+        //         const [name] = UnitName(target);
+        //         this.Debug("%s is worldboss (%s)", target, name);
         //     }
         //     return isWorldBoss || (dep <= 3 && RecursiveScanTargets(`${target}target`, dep + 1));
         // }

--- a/src/states/Future.ts
+++ b/src/states/Future.ts
@@ -870,7 +870,7 @@ export class OvaleFutureClass
                     if (name == targetName) {
                         targetGUID = this.ovaleGuid.getUnitGUID("focus");
                     } else if (UnitExists("mouseover")) {
-                        name = UnitName("mouseover");
+                        [name] = UnitName("mouseover");
                         if (name == targetName) {
                             targetGUID = UnitGUID("mouseover");
                         }

--- a/src/states/conditions.ts
+++ b/src/states/conditions.ts
@@ -2428,7 +2428,8 @@ export class OvaleConditions {
 	 @return A boolean value.
      */
     private name = (atTime: number, target: string) => {
-        return returnConstant(UnitName(target));
+        const [name] = UnitName(target);
+        return returnConstant(name);
     };
 
     /** Test if the game is on a PTR server
@@ -2502,11 +2503,16 @@ export class OvaleConditions {
     ) => {
         const name = namedParams.name;
         const target = "pet";
-        const boolean =
-            UnitExists(target) &&
-            !UnitIsDead(target) &&
-            (name == undefined || name == UnitName(target));
-        return returnBoolean(boolean);
+        let value = false;
+        if (UnitExists(target) && !UnitIsDead(target)) {
+            if (name == undefined) {
+                value = true;
+            } else {
+                const [petName] = UnitName(target);
+                value = name == petName;
+            }
+        }
+        return returnBoolean(value);
     };
 
     /**  Return the maximum power of the given power type on the target.


### PR DESCRIPTION
Change all call sites for `UnitName()` since the correct return
value is a tuple [name, realm], and not just a name string.