### PR TITLE
fix: change usage of UnitName() to GetUnitName()

### DIFF
--- a/src/engine/guid.ts
+++ b/src/engine/guid.ts
@@ -8,7 +8,7 @@ import {
     LuaObj,
 } from "@wowts/lua";
 import { insert } from "@wowts/table";
-import { GetTime, UnitGUID, UnitName } from "@wowts/wow-mock";
+import { GetTime, GetUnitName, UnitGUID } from "@wowts/wow-mock";
 import { AceModule } from "@wowts/tsaddon";
 import { OvaleClass } from "../Ovale";
 import { Tracer, DebugTools } from "./debug";
@@ -239,7 +239,7 @@ export class Guids {
     }
     updateUnit(unitId: string) {
         const guid = UnitGUID(unitId);
-        const name = UnitName(unitId);
+        const name = GetUnitName(unitId, true);
         const previousGUID = this.unitGUID[unitId];
         const previousName = this.unitName[unitId];
         if (!guid || guid != previousGUID) {
@@ -327,7 +327,7 @@ export class Guids {
     }
     getUnitName(unitId: string) {
         if (unitId) {
-            return this.unitName[unitId] || UnitName(unitId);
+            return this.unitName[unitId] || GetUnitName(unitId, true);
         }
         return undefined;
     }

--- a/src/states/BossMod.ts
+++ b/src/states/BossMod.ts
@@ -107,7 +107,7 @@ export class OvaleBossModClass {
         //     let dep = depth || 1;
         //     isWorldBoss = target != undefined && UnitExists(target) && UnitLevel(target) < 0;
         //     if (isWorldBoss) {
-        //         this.Debug("%s is worldboss (%s)", target, UnitName(target));
+        //         this.Debug("%s is worldboss (%s)", target, GetUnitName(target, true));
         //     }
         //     return isWorldBoss || (dep <= 3 && RecursiveScanTargets(`${target}target`, dep + 1));
         // }

--- a/src/states/Future.ts
+++ b/src/states/Future.ts
@@ -25,11 +25,11 @@ import { insert, remove } from "@wowts/table";
 import {
     GetSpellInfo,
     GetTime,
+    GetUnitName,
     UnitCastingInfo,
     UnitChannelInfo,
     UnitExists,
     UnitGUID,
-    UnitName,
     CombatLogGetCurrentEventInfo,
 } from "@wowts/wow-mock";
 import { OvaleStateClass, StateModule, States } from "../engine/state";
@@ -870,7 +870,7 @@ export class OvaleFutureClass
                     if (name == targetName) {
                         targetGUID = this.ovaleGuid.getUnitGUID("focus");
                     } else if (UnitExists("mouseover")) {
-                        name = UnitName("mouseover");
+                        name = GetUnitName("mouseover", true);
                         if (name == targetName) {
                             targetGUID = UnitGUID("mouseover");
                         }

--- a/src/states/conditions.ts
+++ b/src/states/conditions.ts
@@ -21,6 +21,7 @@ import {
     GetItemCount,
     GetNumTrackingTypes,
     GetTrackingInfo,
+    GetUnitName,
     GetUnitSpeed,
     HasFullControl,
     IsStealthed,
@@ -40,7 +41,6 @@ import {
     UnitIsPVP,
     UnitIsUnit,
     UnitLevel,
-    UnitName,
     UnitPower,
     UnitPowerMax,
     UnitRace,
@@ -2428,7 +2428,7 @@ export class OvaleConditions {
 	 @return A boolean value.
      */
     private name = (atTime: number, target: string) => {
-        return returnConstant(UnitName(target));
+        return returnConstant(GetUnitName(target, true));
     };
 
     /** Test if the game is on a PTR server
@@ -2505,7 +2505,7 @@ export class OvaleConditions {
         const boolean =
             UnitExists(target) &&
             !UnitIsDead(target) &&
-            (name == undefined || name == UnitName(target));
+            (name == undefined || name == GetUnitName(target, true));
         return returnBoolean(boolean);
     };
 


### PR DESCRIPTION
This avoids needing to do the name-realm dance to get the correct
name of the unit.