### PR TITLE
fix: be explicit about method return type as a hint to tstolua

### DIFF
--- a/src/tools/Queue.ts
+++ b/src/tools/Queue.ts
@@ -86,11 +86,11 @@ export class Deque<T> {
         return (index > 1 && index - 1) || this.capacity;
     };
 
-    backToFrontIterator() {
+    backToFrontIterator(): Iterator<T> {
         return new DequeBackToFrontIterator<T>(this);
     }
 
-    frontToBackIterator() {
+    frontToBackIterator(): Iterator<T> {
         return new DequeFrontToBackIterator<T>(this);
     }
 
@@ -117,7 +117,7 @@ export class Deque<T> {
     asArray(reverse?: boolean) {
         const t: LuaArray<T> = {};
         let index = 1;
-        const iterator =
+        const iterator: Iterator<T> =
             (reverse == true && this.backToFrontIterator()) ||
             this.frontToBackIterator();
         while (iterator.next()) {
@@ -302,7 +302,7 @@ export class Deque<T> {
 }
 
 export class Queue<T> extends Deque<T> {
-    iterator() {
+    iterator(): Iterator<T> {
         return this.frontToBackIterator();
     }
 }
@@ -313,7 +313,7 @@ export class Stack<T> extends Deque<T> {
         return super.back();
     }
 
-    iterator() {
+    iterator(): Iterator<T> {
         return this.backToFrontIterator();
     }
 }

--- a/src/tools/list.ts
+++ b/src/tools/list.ts
@@ -80,11 +80,11 @@ export class List<T> {
         return (this.head && this.head.prev.value) || undefined;
     }
 
-    backToFrontIterator() {
+    backToFrontIterator(): Iterator<T> {
         return new ListBackToFrontIterator<T>(this);
     }
 
-    frontToBackIterator() {
+    frontToBackIterator(): Iterator<T> {
         return new ListFrontToBackIterator<T>(this);
     }
 


### PR DESCRIPTION
This fixes a codegen issue where `tstolua` could not guess that the
return type of `queue.frontToBackIterator()` was a class type, and
the same issue for `list`.