### PR TITLE
refactor: move COMBAT_LOG_EVENT-related code to a new module

### DIFF
--- a/src/engine/combat-log-event.ts
+++ b/src/engine/combat-log-event.ts
@@ -1,0 +1,736 @@
+import aceEvent, { AceEvent } from "@wowts/ace_event-3.0";
+import { LuaArray, LuaObj, next, truthy, unpack } from "@wowts/lua";
+import { find } from "@wowts/string";
+import { AceModule } from "@wowts/tsaddon";
+import {
+    COMBATLOG_OBJECT_AFFILIATION_MINE,
+    COMBATLOG_OBJECT_AFFILIATION_PARTY,
+    COMBATLOG_OBJECT_AFFILIATION_RAID,
+    COMBATLOG_OBJECT_REACTION_FRIENDLY,
+    CombatLogGetCurrentEventInfo,
+    Enum,
+} from "@wowts/wow-mock";
+import { OvaleClass } from "../Ovale";
+import { DebugTools, Tracer } from "./debug";
+
+// from Interface/AddOns/Blizzard_CombatLog/Blizzard_CombatLog.lua
+export type CombatLogSubEvent =
+    | "ENVIRONMENTAL_DAMAGE"
+    | "SWING_DAMAGE"
+    | "SWING_MISSED"
+    | "RANGE_DAMAGE"
+    | "RANGE_MISSED"
+    | "SPELL_CAST_START"
+    | "SPELL_CAST_SUCCESS"
+    | "SPELL_CAST_FAILED"
+    | "SPELL_MISSED"
+    | "SPELL_DAMAGE"
+    | "SPELL_HEAL"
+    | "SPELL_ENERGIZE"
+    | "SPELL_DRAIN"
+    | "SPELL_LEECH"
+    | "SPELL_SUMMON"
+    | "SPELL_RESURRECT"
+    | "SPELL_CREATE"
+    | "SPELL_INSTAKILL"
+    | "SPELL_INTERRUPT"
+    | "SPELL_EXTRA_ATTACKS"
+    | "SPELL_DURABILITY_DAMAGE"
+    | "SPELL_DURABILITY_DAMAGE_ALL"
+    | "SPELL_AURA_APPLIED"
+    | "SPELL_AURA_APPLIED_DOSE"
+    | "SPELL_AURA_REMOVED"
+    | "SPELL_AURA_REMOVED_DOSE"
+    | "SPELL_AURA_BROKEN"
+    | "SPELL_AURA_BROKEN_SPELL"
+    | "SPELL_AURA_REFRESH"
+    | "SPELL_DISPEL"
+    | "SPELL_STOLEN"
+    | "ENCHANT_APPLIED"
+    | "ENCHANT_REMOVED"
+    | "SPELL_PERIODIC_MISSED"
+    | "SPELL_PERIODIC_DAMAGE"
+    | "SPELL_PERIODIC_HEAL"
+    | "SPELL_PERIODIC_ENERGIZE"
+    | "SPELL_PERIODIC_DRAIN"
+    | "SPELL_PERIODIC_LEECH"
+    | "SPELL_DISPEL_FAILED"
+    | "DAMAGE_SHIELD"
+    | "DAMAGE_SHIELD_MISSED"
+    | "DAMAGE_SPLIT"
+    | "PARTY_KILL"
+    | "UNIT_DIED"
+    | "UNIT_DESTROYED"
+    | "SPELL_BUILDING_DAMAGE"
+    | "SPELL_BUILDING_HEAL"
+    | "UNIT_DISSIPATES";
+
+export type EventPrefix =
+    | "SWING"
+    | "RANGE"
+    | "SPELL"
+    | "SPELL_PERIODIC"
+    | "SPELL_BUILDING"
+    | "ENVIRONMENTAL"
+    | "ENCHANT_APPLIED"
+    | "ENCHANT_REMOVED"
+    | "PARTY_KILL"
+    | "UNIT_DIED"
+    | "UNIT_DESTROYED"
+    | "UNIT_DISSIPATES";
+
+export interface PayloadHeader {
+    type: EventPrefix;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface SwingPayloadHeader extends PayloadHeader {}
+
+export interface RangePayloadHeader extends PayloadHeader {
+    spellId: number;
+    spellName: string;
+    school: number;
+}
+
+export interface SpellPayloadHeader extends PayloadHeader {
+    spellId: number;
+    spellName: string;
+    school: number;
+}
+
+export interface SpellPeriodicPayloadHeader extends PayloadHeader {
+    spellId: number;
+    spellName: string;
+    school: number;
+}
+
+export interface SpellBuildingPayloadHeader extends PayloadHeader {
+    spellId: number;
+    spellName: string;
+    school: number;
+}
+
+export interface EnchantAppliedPayloadHeader extends PayloadHeader {
+    spellName: string;
+    itemId: number;
+    itemName: string;
+}
+
+export interface EnchantRemovedPayloadHeader extends PayloadHeader {
+    spellName: string;
+    itemId: number;
+    itemName: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface PartyKillPayloadHeader extends PayloadHeader {}
+
+export interface UnitDiedPayloadHeader extends PayloadHeader {
+    recapId: number;
+    unconsciousOnDeath: boolean;
+}
+
+export interface UnitDestroyedPayloadHeader extends PayloadHeader {
+    recapId: number;
+    unconsciousOnDeath: boolean;
+}
+
+export interface UnitDissipatesPayloadHeader extends PayloadHeader {
+    recapId: number;
+    unconsciousOnDeath: boolean;
+}
+
+type EnvironmentalType =
+    | "Drowning"
+    | "Falling"
+    | "Fatigue"
+    | "Fire"
+    | "Lava"
+    | "Slime";
+
+export interface EnvironmentalPayloadHeader extends PayloadHeader {
+    environmentalType: EnvironmentalType;
+}
+
+export type EventSuffix =
+    | "DAMAGE"
+    | "MISSED"
+    | "HEAL"
+    | "HEAL_ABSORBED"
+    | "ENERGIZE"
+    | "DRAIN"
+    | "LEECH"
+    | "INTERRUPT"
+    | "DISPEL"
+    | "DISPEL_FAILED"
+    | "STOLEN"
+    | "EXTRA_ATTACKS"
+    | "AURA_APPLIED"
+    | "AURA_REMOVED"
+    | "AURA_APPLIED_DOSE"
+    | "AURA_REMOVED_DOSE"
+    | "AURA_REFRESH"
+    | "AURA_BROKEN"
+    | "AURA_BROKEN_SPELL"
+    | "CAST_START"
+    | "CAST_SUCCESS"
+    | "CAST_FAILED"
+    | "INSTAKILL"
+    | "DURABILITY_DAMAGE"
+    | "DURABILITY_DAMAGE_ALL"
+    | "CREATE"
+    | "SUMMON"
+    | "DISSIPATES";
+
+type AuraType = "BUFF" | "DEBUFF";
+
+type MissType =
+    | "ABSORB"
+    | "BLOCK"
+    | "DEFLECT"
+    | "DODGE"
+    | "EVADE"
+    | "IMMUNE"
+    | "MISS"
+    | "PARRY"
+    | "REFLECT"
+    | "RESIST";
+
+export interface Payload {
+    type: EventSuffix;
+}
+
+export interface DamagePayload extends Payload {
+    amount: number;
+    overkill: number;
+    school: number;
+    resisted: number;
+    blocked: number;
+    absorbed: number;
+    critical: boolean;
+    glancing: boolean;
+    crushing: boolean;
+    isOffHand: boolean;
+}
+
+export interface MissedPayload extends Payload {
+    missType: MissType;
+    isOffHand: boolean;
+    amountMissed: number;
+    critical: boolean;
+}
+
+export interface HealPayload extends Payload {
+    amount: number;
+    overhealing: number;
+    absorbed: number;
+    critical: boolean;
+}
+
+export interface HealAbsorbedPayload extends Payload {
+    guid: string;
+    name: string;
+    flags: number;
+    raidFlags: number;
+    spellId: number;
+    spellName: string;
+    school: number;
+    amount: number;
+}
+
+export interface EnergizePayload extends Payload {
+    amount: number;
+    overEnergize: number;
+    powerType: number; // Enum.PowerType
+    alternatePowerType: number; // Enum.PowerType
+}
+
+export interface DrainPayload extends Payload {
+    amount: number;
+    powerType: number; // Enum.PowerType
+    extraAmount: number;
+}
+
+export interface LeechPayload extends Payload {
+    amount: number;
+    powerType: number; // Enum.PowerType
+    extraAmount: number;
+}
+
+export interface InterruptPayload extends Payload {
+    spellId: number;
+    spellName: string;
+    school: number;
+}
+
+export interface DispelPayload extends Payload {
+    spellId: number;
+    spellName: string;
+    school: number;
+    auraType: AuraType;
+}
+
+export interface DispelFailedPayload extends Payload {
+    spellId: number;
+    spellName: string;
+    school: number;
+}
+
+export interface StolenPayload extends Payload {
+    spellId: number;
+    spellName: string;
+    school: number;
+    auraType: AuraType;
+}
+
+export interface ExtraAttacksPayload extends Payload {
+    amount: number;
+}
+
+export interface AuraAppliedPayload extends Payload {
+    auraType: AuraType;
+    amount: number;
+}
+
+export interface AuraRemovedPayload extends Payload {
+    auraType: AuraType;
+    amount: number;
+}
+
+export interface AuraAppliedDosePayload extends Payload {
+    auraType: AuraType;
+    amount: number;
+}
+
+export interface AuraRemovedDosePayload extends Payload {
+    auraType: AuraType;
+    amount: number;
+}
+
+export interface AuraRefreshPayload extends Payload {
+    auraType: AuraType;
+    amount: number;
+}
+
+export interface AuraBrokenPayload extends Payload {
+    auraType: AuraType;
+}
+
+export interface AuraBrokenSpellPayload extends Payload {
+    spellId: number;
+    spellName: string;
+    school: number;
+    auraType: AuraType;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface CastStartPayload extends Payload {}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface CastSuccessPayload extends Payload {}
+
+export interface CastFailedPayload extends Payload {
+    failedType: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface InstaKillPayload extends Payload {}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DurabilityDamagePayload extends Payload {}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DurabilityDamageAllPayload extends Payload {}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface CreatePayload extends Payload {}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface SummonPayload extends Payload {}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DissipatesPayload extends Payload {}
+
+export const unitFlag: LuaObj<LuaObj<number>> = {
+    type: {
+        mask: 0xfc00, // COMBATLOG_OBJECT_TYPE_MASK
+        object: 0x4000, // COMBATLOG_OBJECT_TYPE_OBJECT
+        guardian: 0x2000, // COMBATLOG_OBJECT_TYPE_GUARDIAN
+        pet: 0x1000, // COMBATLOG_OBJECT_TYPE_PET
+        npc: 0x800, // COMBATLOG_OBJECT_TYPE_NPC
+        player: 0x400, // COMBATLOG_OBJECT_TYPE_PLAYER
+    },
+    controller: {
+        mask: 0x300, // COMBATLOG_OBJECT_CONTROL_MASK
+        npc: 0x200, // COMBATLOG_OBJECT_CONTROL_NPC
+        player: 0x100, // COMBATLOG_OBJECT_CONTROL_PLAYER
+    },
+    reaction: {
+        mask: 0xf0, // COMBATLOG_OBJECT_REACTION_MASK
+        hostile: 0x40, // COMBATLOG_OBJECT_REACTION_HOSTILE
+        neutral: 0x20, // COMBATLOG_OBJECT_REACTION_NEUTRAL
+        friendly: COMBATLOG_OBJECT_REACTION_FRIENDLY,
+    },
+    affiliation: {
+        mask: 0xf, // COMBATLOG_OBJECT_AFFILIATION_MASK
+        outsider: 0x8, // COMBATLOG_OBJECT_AFFILIATION_MASK
+        raid: COMBATLOG_OBJECT_AFFILIATION_RAID,
+        party: COMBATLOG_OBJECT_AFFILIATION_PARTY,
+        mine: COMBATLOG_OBJECT_AFFILIATION_MINE,
+    },
+};
+
+export const raidFlag: LuaObj<LuaObj<number>> = {
+    raidTarget: {
+        mask: 0xff, // COMBATLOG_OBJECT_RAIDTARGET_MASK
+        skull: 0x80, // COMBATLOG_OBJECT_RAIDTARGET8
+        cross: 0x40, // COMBATLOG_OBJECT_RAIDTARGET7
+        square: 0x20, // COMBATLOG_OBJECT_RAIDTARGET6
+        moon: 0x10, // COMBATLOG_OBJECT_RAIDTARGET5
+        triangle: 0x8, // COMBATLOG_OBJECT_RAIDTARGET4
+        diamond: 0x4, // COMBATLOG_OBJECT_RAIDTARGET3
+        circle: 0x2, // COMBATLOG_OBJECT_RAIDTARGET2
+        star: 0x1, // COMBATLOG_OBJECT_RAIDTARGET1
+    },
+};
+
+export class CombatLogEvent {
+    private module: AceModule & AceEvent;
+    private tracer: Tracer;
+
+    private registry: LuaObj<LuaObj<boolean>> = {};
+    private arg: LuaArray<any> = {};
+
+    timestamp = 0;
+    subEvent: CombatLogSubEvent = "SWING_DAMAGE";
+    hideCaster = false;
+    sourceGUID = "";
+    sourceName = "";
+    sourceFlags = 0;
+    sourceRaidFlags = 0;
+    destGUID = "";
+    destName = "";
+    destFlags = 0;
+    destRaidFlags = 0;
+    header: PayloadHeader = { type: "SWING" };
+    payload: Payload = { type: "DAMAGE" };
+
+    constructor(ovale: OvaleClass, debug: DebugTools) {
+        this.module = ovale.createModule(
+            "CombatLogEvent",
+            this.onEnable,
+            this.onDisable,
+            aceEvent
+        );
+        this.tracer = debug.create(this.module.GetName());
+    }
+
+    private onEnable = () => {
+        this.module.RegisterEvent(
+            "COMBAT_LOG_EVENT_UNFILTERED",
+            this.onCombatLogEventUnfiltered
+        );
+    };
+
+    private onDisable = () => {
+        this.module.UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED");
+    };
+
+    private onCombatLogEventUnfiltered = (event: string) => {
+        const arg = this.arg;
+        [
+            arg[1],
+            arg[2],
+            arg[3],
+            arg[4],
+            arg[5],
+            arg[6],
+            arg[7],
+            arg[8],
+            arg[9],
+            arg[10],
+            arg[11],
+            arg[12],
+            arg[13],
+            arg[14],
+            arg[15],
+            arg[16],
+            arg[17],
+            arg[18],
+            arg[19],
+            arg[20],
+            arg[21],
+            arg[22],
+            arg[23],
+            arg[24],
+        ] = CombatLogGetCurrentEventInfo();
+
+        const subEvent = arg[2];
+        const tokens = this.registry[subEvent];
+        const isRegisteredEvent = (tokens && next(tokens) && true) || false;
+        if (!isRegisteredEvent) return;
+
+        this.timestamp = (arg[1] as number) || 0;
+        this.subEvent = subEvent as CombatLogSubEvent;
+        this.hideCaster = ((arg[3] as boolean) && true) || false;
+        this.sourceGUID = (arg[4] as string) || "";
+        this.sourceName = (arg[5] as string) || "";
+        this.sourceFlags = (arg[6] as number) || 0;
+        this.sourceRaidFlags = arg[7] as number;
+        this.destGUID = (arg[8] as string) || "";
+        this.destName = (arg[9] as string) || "";
+        this.destFlags = (arg[10] as number) || 0;
+        this.destRaidFlags = (arg[11] as number) || 0;
+
+        if (subEvent == "ENCHANT_APPLIED") {
+            const header = this.header as EnchantAppliedPayloadHeader;
+            header.type = "ENCHANT_APPLIED";
+            header.spellName = (arg[12] as string) || "";
+            header.itemId = (arg[13] as number) || 0;
+            header.itemName = (arg[14] as string) || "";
+        } else if (subEvent == "ENCHANT_REMOVED") {
+            const header = this.header as EnchantRemovedPayloadHeader;
+            header.type = "ENCHANT_APPLIED";
+            header.spellName = (arg[12] as string) || "";
+            header.itemId = (arg[13] as number) || 0;
+            header.itemName = (arg[14] as string) || "";
+        } else if (subEvent == "PARTY_KILL") {
+            this.header.type = "PARTY_KILL";
+        } else if (subEvent == "UNIT_DIED") {
+            const header = this.header as UnitDiedPayloadHeader;
+            header.type = "UNIT_DIED";
+            header.recapId = (arg[12] as number) || 1;
+            header.unconsciousOnDeath = ((arg[13] as boolean) && true) || false;
+        } else if (subEvent == "UNIT_DESTROYED") {
+            const header = this.header as UnitDestroyedPayloadHeader;
+            header.type = "UNIT_DESTROYED";
+            header.recapId = (arg[12] as number) || 1;
+            header.unconsciousOnDeath = ((arg[13] as boolean) && true) || false;
+        } else if (subEvent == "UNIT_DISSIPATES") {
+            const header = this.header as UnitDissipatesPayloadHeader;
+            header.type = "UNIT_DISSIPATES";
+            header.recapId = (arg[12] as number) || 1;
+            header.unconsciousOnDeath = ((arg[13] as boolean) && true) || false;
+        } else {
+            let index = 12;
+            if (truthy(find(subEvent, "^SWING_"))) {
+                this.header.type = "SWING";
+                index = 12;
+            } else if (truthy(find(subEvent, "^RANGE_"))) {
+                const header = this.header as RangePayloadHeader;
+                header.type = "RANGE";
+                header.spellId = (arg[12] as number) || 0;
+                header.spellName = (arg[13] as string) || "";
+                header.school = (arg[14] as number) || 0;
+                index = 15;
+            } else if (truthy(find(subEvent, "^SPELL_PERIODIC_"))) {
+                const header = this.header as SpellPeriodicPayloadHeader;
+                header.type = "SPELL_PERIODIC";
+                header.spellId = (arg[12] as number) || 0;
+                header.spellName = (arg[13] as string) || "";
+                header.school = (arg[14] as number) || 0;
+                index = 15;
+            } else if (truthy(find(subEvent, "^SPELL_BUILDING"))) {
+                const header = this.header as SpellBuildingPayloadHeader;
+                header.type = "SPELL_BUILDING";
+                header.spellId = (arg[12] as number) || 0;
+                header.spellName = (arg[13] as string) || "";
+                header.school = (arg[14] as number) || 0;
+                index = 15;
+            } else if (
+                truthy(find(subEvent, "^SPELL_")) ||
+                truthy(find(subEvent, "^DAMAGE_"))
+            ) {
+                const header = this.header as SpellPayloadHeader;
+                header.type = "SPELL";
+                header.spellId = (arg[12] as number) || 0;
+                header.spellName = (arg[13] as string) || "";
+                header.school = (arg[14] as number) || 0;
+                index = 15;
+            } else if (truthy(find(subEvent, "^ENVIRONMENTAL"))) {
+                const header = this.header as EnvironmentalPayloadHeader;
+                header.type = "ENVIRONMENTAL";
+                header.environmentalType =
+                    (arg[12] as EnvironmentalType) || "Fire";
+                index = 13;
+            }
+            if (
+                truthy(find(subEvent, "_DAMAGE$")) ||
+                truthy(find(subEvent, "_SPLIT$")) ||
+                truthy(find(subEvent, "_SHIELD$"))
+            ) {
+                const payload = this.payload as DamagePayload;
+                payload.type = "DAMAGE";
+                payload.amount = (arg[index] as number) || 0;
+                payload.overkill = (arg[index + 1] as number) || 0;
+                payload.school = (arg[index + 2] as number) || 0;
+                payload.resisted = (arg[index + 3] as number) || 0;
+                payload.blocked = (arg[index + 4] as number) || 0;
+                payload.absorbed = (arg[index + 5] as number) || 0;
+                payload.critical =
+                    ((arg[index + 6] as boolean) && true) || false;
+                payload.glancing =
+                    ((arg[index + 7] as boolean) && true) || false;
+                payload.crushing =
+                    ((arg[index + 8] as boolean) && true) || false;
+                payload.isOffHand =
+                    ((arg[index + 9] as boolean) && true) || false;
+            } else if (truthy(find(subEvent, "_MISSED$"))) {
+                const payload = this.payload as MissedPayload;
+                payload.type = "MISSED";
+                payload.missType = (arg[index] as MissType) || "MISS";
+                payload.isOffHand =
+                    ((arg[index + 1] as boolean) && true) || false;
+                payload.amountMissed = (arg[index + 2] as number) || 0;
+                payload.critical =
+                    ((arg[index + 3] as boolean) && true) || false;
+            } else if (truthy(find(subEvent, "_HEAL$"))) {
+                const payload = this.payload as HealPayload;
+                payload.type = "HEAL";
+                payload.amount = (arg[index] as number) || 0;
+                payload.overhealing = (arg[index + 2] as number) || 0;
+                payload.absorbed = (arg[index + 3] as number) || 0;
+                payload.critical =
+                    ((arg[index + 4] as boolean) && true) || false;
+            } else if (truthy(find(subEvent, "_HEAL_ABSORBED$"))) {
+                const payload = this.payload as HealAbsorbedPayload;
+                payload.type = "HEAL_ABSORBED";
+                payload.guid = (arg[index] as string) || "";
+                payload.name = (arg[index + 1] as string) || "";
+                payload.flags = (arg[index + 2] as number) || 0;
+                payload.raidFlags = (arg[index + 3] as number) || 0;
+                payload.spellId = (arg[index + 4] as number) || 0;
+                payload.spellName = (arg[index + 5] as string) || "";
+                payload.school = (arg[index + 6] as number) || 0;
+                payload.amount = (arg[index + 7] as number) || 0;
+            } else if (truthy(find(subEvent, "_ENERGIZE$"))) {
+                const payload = this.payload as EnergizePayload;
+                payload.type = "ENERGIZE";
+                payload.amount = (arg[index] as number) || 0;
+                payload.overEnergize = (arg[index + 1] as number) || 0;
+                payload.powerType =
+                    (arg[index + 2] as number) || Enum.PowerType.None;
+                payload.alternatePowerType =
+                    (arg[index + 3] as number) || Enum.PowerType.Alternate;
+            } else if (truthy(find(subEvent, "_DRAIN$"))) {
+                const payload = this.payload as DrainPayload;
+                payload.type = "DRAIN";
+                payload.amount = (arg[index] as number) || 0;
+                payload.powerType =
+                    (arg[index + 1] as number) || Enum.PowerType.None;
+                payload.extraAmount = (arg[index + 2] as number) || 0;
+            } else if (truthy(find(subEvent, "_LEECH$"))) {
+                const payload = this.payload as LeechPayload;
+                payload.type = "LEECH";
+                payload.amount = (arg[index] as number) || 0;
+                payload.powerType =
+                    (arg[index + 1] as number) || Enum.PowerType.None;
+                payload.extraAmount = (arg[index + 2] as number) || 0;
+            } else if (truthy(find(subEvent, "_INTERRUPT$"))) {
+                const payload = this.payload as InterruptPayload;
+                payload.type = "INTERRUPT";
+                payload.spellId = (arg[index] as number) || 0;
+                payload.spellName = (arg[index + 1] as string) || "";
+                payload.school = (arg[index + 2] as number) || 0;
+            } else if (truthy(find(subEvent, "_DISPEL$"))) {
+                const payload = this.payload as DispelPayload;
+                payload.type = "DISPEL";
+                payload.spellId = (arg[index] as number) || 0;
+                payload.spellName = (arg[index + 1] as string) || "";
+                payload.school = (arg[index + 2] as number) || 0;
+                payload.auraType = (arg[index + 3] as AuraType) || "DEBUFF";
+            } else if (truthy(find(subEvent, "_DISPEL_FAILED$"))) {
+                const payload = this.payload as DispelFailedPayload;
+                payload.type = "DISPEL_FAILED";
+                payload.spellId = (arg[index] as number) || 0;
+                payload.spellName = (arg[index + 1] as string) || "";
+                payload.school = (arg[index + 2] as number) || 0;
+            } else if (truthy(find(subEvent, "_STOLEN$"))) {
+                const payload = this.payload as StolenPayload;
+                payload.type = "STOLEN";
+                payload.spellId = (arg[index] as number) || 0;
+                payload.spellName = (arg[index + 1] as string) || "";
+                payload.school = (arg[index + 2] as number) || 0;
+                payload.auraType = (arg[index + 3] as AuraType) || "DEBUFF";
+            } else if (truthy(find(subEvent, "_EXTRA_ATTACKS$"))) {
+                const payload = this.payload as ExtraAttacksPayload;
+                payload.type = "EXTRA_ATTACKS";
+                payload.amount = (arg[index] as number) || 0;
+            } else if (truthy(find(subEvent, "_AURA_APPLIED$"))) {
+                const payload = this.payload as AuraAppliedPayload;
+                payload.type = "AURA_APPLIED";
+                payload.auraType = (arg[index] as AuraType) || "DEBUFF";
+                payload.amount = (arg[index + 1] as number) || 0;
+            } else if (truthy(find(subEvent, "_AURA_REMOVED$"))) {
+                const payload = this.payload as AuraRemovedPayload;
+                payload.type = "AURA_REMOVED";
+                payload.auraType = (arg[index] as AuraType) || "DEBUFF";
+                payload.amount = (arg[index + 1] as number) || 0;
+            } else if (truthy(find(subEvent, "_AURA_APPLIED_DOSE$"))) {
+                const payload = this.payload as AuraAppliedDosePayload;
+                payload.type = "AURA_APPLIED_DOSE";
+                payload.auraType = (arg[index] as AuraType) || "DEBUFF";
+                payload.amount = (arg[index + 1] as number) || 0;
+            } else if (truthy(find(subEvent, "_AURA_REMOVED_DOSE$"))) {
+                const payload = this.payload as AuraRemovedDosePayload;
+                payload.type = "AURA_REMOVED_DOSE";
+                payload.auraType = (arg[index] as AuraType) || "DEBUFF";
+                payload.amount = (arg[index + 1] as number) || 0;
+            } else if (truthy(find(subEvent, "_AURA_REFRESH$"))) {
+                const payload = this.payload as AuraRefreshPayload;
+                payload.type = "AURA_REFRESH";
+                payload.auraType = (arg[index] as AuraType) || "DEBUFF";
+                payload.amount = (arg[index + 1] as number) || 0;
+            } else if (truthy(find(subEvent, "_AURA_BROKEN$"))) {
+                const payload = this.payload as AuraBrokenPayload;
+                payload.type = "AURA_BROKEN";
+                payload.auraType = (arg[index] as AuraType) || "DEBUFF";
+            } else if (truthy(find(subEvent, "_AURA_BROKEN_SPELL$"))) {
+                const payload = this.payload as AuraBrokenSpellPayload;
+                payload.type = "AURA_BROKEN_SPELL";
+                payload.spellId = (arg[index] as number) || 0;
+                payload.spellName = (arg[index + 1] as string) || "";
+                payload.school = (arg[index + 2] as number) || 0;
+                payload.auraType = (arg[index + 3] as AuraType) || "DEBUFF";
+            } else if (truthy(find(subEvent, "_CAST_START$"))) {
+                this.payload.type = "CAST_START";
+            } else if (truthy(find(subEvent, "_CAST_SUCCESS$"))) {
+                this.payload.type = "CAST_SUCCESS";
+            } else if (truthy(find(subEvent, "_CAST_FAILED$"))) {
+                const payload = this.payload as CastFailedPayload;
+                payload.type = "CAST_FAILED";
+                payload.failedType = (arg[index] as string) || "CAST_FAILED";
+            } else if (truthy(find(subEvent, "_INSTAKILL$"))) {
+                this.payload.type = "INSTAKILL";
+            } else if (truthy(find(subEvent, "_DURABILITY_DAMAGE$"))) {
+                this.payload.type = "DURABILITY_DAMAGE";
+            } else if (truthy(find(subEvent, "_DURABILITY_DAMAGE_ALL$"))) {
+                this.payload.type = "DURABILITY_DAMAGE_ALL";
+            } else if (truthy(find(subEvent, "_CREATE$"))) {
+                this.payload.type = "CREATE";
+            } else if (truthy(find(subEvent, "_SUMMON$"))) {
+                this.payload.type = "SUMMON";
+            } else if (truthy(find(subEvent, "_DISSIPATES$"))) {
+                this.payload.type = "DISSIPATES";
+            }
+        }
+        this.tracer.debug(this.subEvent, this.getCurrentEventInfo());
+        this.module.SendMessage("Ovale_CombatLogEvent", subEvent);
+    };
+
+    registerEvent = (event: string, token: any) => {
+        const tokens = this.registry[event] || {};
+        const key = token as unknown as string;
+        tokens[key] = true;
+        this.registry[event] = tokens;
+    };
+
+    unregisterEvent = (event: string, token: any) => {
+        const tokens = this.registry[event];
+        if (tokens) {
+            const key = token as unknown as string;
+            delete tokens[key];
+            if (!next(tokens)) {
+                delete this.registry[event];
+            }
+        }
+    };
+
+    getCurrentEventInfo() {
+        return unpack(this.arg);
+    }
+}

--- a/src/engine/combat-log-event.ts
+++ b/src/engine/combat-log-event.ts
@@ -465,10 +465,9 @@ export class CombatLogEvent {
         ] = CombatLogGetCurrentEventInfo();
 
         const subEvent = arg[2];
-        const handlers = this.registry[subEvent];
-        const isRegisteredEvent = (handlers && next(handlers) && true) || false;
-        if (!isRegisteredEvent) return;
-
+        if (!this.hasEventHandler(subEvent)) {
+            return;
+        }
         this.timestamp = (arg[1] as number) || 0;
         this.subEvent = subEvent as CombatLogSubEvent;
         this.hideCaster = ((arg[3] as boolean) && true) || false;
@@ -715,6 +714,11 @@ export class CombatLogEvent {
         }
         this.tracer.debug(this.subEvent, this.getCurrentEventInfo());
         this.fire(this.subEvent);
+    };
+
+    hasEventHandler = (event: string) => {
+        const handlers = this.registry[event];
+        return (handlers && next(handlers) && true) || false;
     };
 
     fire = (event: string) => {

--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -398,6 +398,7 @@ export class IoC {
         this.bossMod = new OvaleBossModClass(this.ovale, this.debug, combat);
         this.demonHunterDemonic = new OvaleDemonHunterDemonicClass(
             this.aura,
+            this.combatLogEvent,
             this.ovale,
             this.debug
         );

--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -157,7 +157,8 @@ export class IoC {
         this.demonHunterSigils = new OvaleSigilClass(
             this.paperDoll,
             this.ovale,
-            this.spellBook
+            this.spellBook,
+            this.combatLogEvent
         );
         const combat = new OvaleCombatClass(
             this.ovale,
@@ -184,7 +185,8 @@ export class IoC {
             this.debug,
             this.ovale,
             this.spellBook,
-            this.power
+            this.power,
+            this.combatLogEvent
         );
         this.eclipse = new Eclipse(
             this.ovale,
@@ -195,7 +197,12 @@ export class IoC {
             this.spellBook
         );
         this.stance = new OvaleStanceClass(this.debug, this.ovale, this.data);
-        this.enemies = new OvaleEnemiesClass(this.guid, this.ovale, this.debug);
+        this.enemies = new OvaleEnemiesClass(
+            this.guid,
+            this.combatLogEvent,
+            this.ovale,
+            this.debug
+        );
         this.future = new OvaleFutureClass(
             this.data,
             this.aura,
@@ -209,13 +216,15 @@ export class IoC {
             this.debug,
             this.stance,
             this.spellBook,
+            this.combatLogEvent,
             runner
         );
         this.health = new OvaleHealthClass(
             this.guid,
             this.ovale,
             this.options,
-            this.debug
+            this.debug,
+            this.combatLogEvent
         );
         this.lossOfControl = new OvaleLossOfControlClass(
             this.ovale,
@@ -267,7 +276,8 @@ export class IoC {
             combat,
             this.baseState,
             this.aura,
-            this.health
+            this.health,
+            this.combatLogEvent
         );
         this.actionBar = new OvaleActionBarClass(
             this.debug,
@@ -296,19 +306,25 @@ export class IoC {
             this.paperDoll,
             this.spellBook,
             this.future,
-            this.power
+            this.power,
+            this.combatLogEvent
         );
         this.version = new OvaleVersionClass(
             this.ovale,
             this.options,
             this.debug
         );
-        this.damageTaken = new OvaleDamageTakenClass(this.ovale, this.debug);
+        this.damageTaken = new OvaleDamageTakenClass(
+            this.ovale,
+            this.debug,
+            this.combatLogEvent
+        );
         this.spellDamage = new OvaleSpellDamageClass(this.ovale);
         this.demonHunterSoulFragments = new OvaleDemonHunterSoulFragmentsClass(
             this.aura,
             this.ovale,
-            this.paperDoll
+            this.paperDoll,
+            this.combatLogEvent
         );
         this.runes = new OvaleRunesClass(
             this.ovale,

--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -3,6 +3,7 @@ import { OvaleScriptsClass } from "./engine/scripts";
 import { OvaleOptionsClass } from "./ui/Options";
 import { OvalePaperDollClass } from "./states/PaperDoll";
 import { OvaleActionBarClass } from "./engine/action-bar";
+import { CombatLogEvent } from "./engine/combat-log-event";
 import { OvaleASTClass } from "./engine/ast";
 import { OvaleAuraClass } from "./states/Aura";
 import { OvaleAzeriteArmor } from "./states/AzeriteArmor";
@@ -69,6 +70,7 @@ export class IoC {
     public baseState: BaseState;
     public bestAction: OvaleBestActionClass;
     public bossMod: OvaleBossModClass;
+    public combatLogEvent: CombatLogEvent;
     public compile: OvaleCompileClass;
     public condition: OvaleConditionClass;
     public conditions: OvaleConditions;
@@ -128,6 +130,7 @@ export class IoC {
         const controls = new Controls();
         const runner = new Runner(this.debug, this.baseState, this.condition);
         this.data = new OvaleDataClass(runner, this.debug);
+        this.combatLogEvent = new CombatLogEvent(this.ovale, this.debug);
         this.equipment = new OvaleEquipmentClass(
             this.ovale,
             this.debug,

--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -319,7 +319,10 @@ export class IoC {
             this.debug,
             this.combatLogEvent
         );
-        this.spellDamage = new OvaleSpellDamageClass(this.ovale);
+        this.spellDamage = new OvaleSpellDamageClass(
+            this.ovale,
+            this.combatLogEvent
+        );
         this.demonHunterSoulFragments = new OvaleDemonHunterSoulFragmentsClass(
             this.aura,
             this.ovale,

--- a/src/states/DamageTaken.ts
+++ b/src/states/DamageTaken.ts
@@ -55,28 +55,22 @@ export class OvaleDamageTakenClass {
             "PLAYER_REGEN_ENABLED",
             this.handlePlayerRegenEnabled
         );
-        this.module.RegisterMessage(
-            "Ovale_CombatLogEvent",
-            this.handleOvaleCombatLogEvent
-        );
         for (const [event] of pairs(damageTakenEvent)) {
-            this.combatLogEvent.registerEvent(event, this);
+            this.combatLogEvent.registerEvent(
+                event,
+                this,
+                this.handleCombatLogEvent
+            );
         }
     };
 
     private handleDisable = () => {
         this.module.UnregisterEvent("PLAYER_REGEN_ENABLED");
-        this.module.UnregisterMessage("Ovale_CombatLogEvent");
-        for (const [event] of pairs(damageTakenEvent)) {
-            this.combatLogEvent.registerEvent(event, this);
-        }
+        this.combatLogEvent.unregisterAllEvents(this);
         pool.drain();
     };
 
-    private handleOvaleCombatLogEvent = (event: string, cleuEvent: string) => {
-        if (!damageTakenEvent[cleuEvent]) {
-            return;
-        }
+    private handleCombatLogEvent = (cleuEvent: string) => {
         const cleu = this.combatLogEvent;
         const destGUID = cleu.destGUID;
         if (destGUID == this.ovale.playerGUID) {
@@ -124,6 +118,7 @@ export class OvaleDamageTakenClass {
             }
         }
     };
+
     private handlePlayerRegenEnabled = (event: string) => {
         pool.drain();
     };

--- a/src/states/DemonHunterDemonic.ts
+++ b/src/states/DemonHunterDemonic.ts
@@ -79,12 +79,16 @@ export class OvaleDemonHunterDemonicClass {
             false;
         if (this.isHavoc && this.hasDemonic) {
             this.debug.debug("We are a havoc DH with Demonic.");
-            this.module.RegisterMessage(
-                "Ovale_CombatLogEvent",
-                this.handleOvaleCombatLogEvent
+            this.combatLogEvent.registerEvent(
+                "SPELL_CAST_SUCCESS",
+                this,
+                this.handleCombatLogEvent
             );
-            this.combatLogEvent.registerEvent("SPELL_CAST_SUCCESS", this);
-            this.combatLogEvent.registerEvent("SPELL_AURA_REMOVED", this);
+            this.combatLogEvent.registerEvent(
+                "SPELL_AURA_REMOVED",
+                this,
+                this.handleCombatLogEvent
+            );
         } else {
             if (!this.isHavoc) {
                 this.debug.debug("We are not a havoc DH.");
@@ -92,21 +96,12 @@ export class OvaleDemonHunterDemonicClass {
                 this.debug.debug("We don't have the Demonic talent.");
             }
             this.dropAura();
-            this.module.UnregisterMessage("Ovale_CombatLogEvent");
-            this.combatLogEvent.unregisterEvent("SPELL_CAST_SUCCESS", this);
-            this.combatLogEvent.unregisterEvent("SPELL_AURA_REMOVED", this);
+            this.combatLogEvent.unregisterAllEvents(this);
         }
     };
-    private handleOvaleCombatLogEvent(event: string, cleuEvent: string) {
-        if (
-            cleuEvent != "SPELL_CAST_SUCCESS" &&
-            cleuEvent != "SPELL_AURA_REMOVED"
-        ) {
-            return;
-        }
+    private handleCombatLogEvent(cleuEvent: string) {
         const cleu = this.combatLogEvent;
-        const sourceGUID = cleu.sourceGUID;
-        if (sourceGUID == this.playerGUID) {
+        if (cleu.sourceGUID == this.playerGUID) {
             if (cleuEvent == "SPELL_CAST_SUCCESS") {
                 const header = cleu.header as SpellPayloadHeader;
                 const spellId = header.spellId;

--- a/src/states/DemonHunterSigils.ts
+++ b/src/states/DemonHunterSigils.ts
@@ -82,31 +82,26 @@ export class OvaleSigilClass implements StateModule {
                 "UNIT_SPELLCAST_SUCCEEDED",
                 this.handleUnitSpellCastSucceeded
             );
-            this.module.RegisterMessage(
-                "Ovale_CombatLogEvent",
-                this.handleOvaleCombatLogEvent
+            this.combatLogEvent.registerEvent(
+                "SPELL_AURA_APPLIED",
+                this,
+                this.handleSpellAuraApplied
             );
-            this.combatLogEvent.registerEvent("SPELL_AURA_APPLIED", this);
         }
     };
     private handleDisable = () => {
         if (this.ovale.playerClass == "DEMONHUNTER") {
             this.module.UnregisterEvent("UNIT_SPELLCAST_SUCCEEDED");
-            this.module.UnregisterMessage("Ovale_CombatLogEvent");
-            this.combatLogEvent.unregisterEvent("SPELL_AURA_APPLIED", this);
+            this.combatLogEvent.unregisterAllEvents(this);
         }
     };
 
-    private handleOvaleCombatLogEvent = (event: string, cleuEvent: string) => {
-        if (
-            cleuEvent != "SPELL_AURA_APPLIED" ||
-            !this.ovalePaperDoll.isSpecialization("vengeance")
-        ) {
+    private handleSpellAuraApplied = (cleuEvent: string) => {
+        if (!this.ovalePaperDoll.isSpecialization("vengeance")) {
             return;
         }
         const cleu = this.combatLogEvent;
-        const sourceGUID = cleu.sourceGUID;
-        if (sourceGUID == this.ovale.playerGUID) {
+        if (cleu.sourceGUID == this.ovale.playerGUID) {
             const header = cleu.header as SpellPayloadHeader;
             const spellId = header.spellId;
             if (sigilEnd[spellId] != undefined) {

--- a/src/states/DemonHunterSigils.ts
+++ b/src/states/DemonHunterSigils.ts
@@ -3,13 +3,10 @@ import { OvaleSpellBookClass } from "./SpellBook";
 import aceEvent, { AceEvent } from "@wowts/ace_event-3.0";
 import { ipairs, LuaObj, LuaArray, tonumber, lualength } from "@wowts/lua";
 import { insert, remove } from "@wowts/table";
-import {
-    GetTime,
-    CombatLogGetCurrentEventInfo,
-    TalentId,
-} from "@wowts/wow-mock";
+import { GetTime, TalentId } from "@wowts/wow-mock";
 import { OvaleClass } from "../Ovale";
 import { AceModule } from "@wowts/tsaddon";
+import { CombatLogEvent, SpellPayloadHeader } from "../engine/combat-log-event";
 import { StateModule } from "../engine/state";
 
 const updateDelay = 0.5;
@@ -64,7 +61,8 @@ export class OvaleSigilClass implements StateModule {
     constructor(
         private ovalePaperDoll: OvalePaperDollClass,
         private ovale: OvaleClass,
-        private ovaleSpellBook: OvaleSpellBookClass
+        private ovaleSpellBook: OvaleSpellBookClass,
+        private combatLogEvent: CombatLogEvent
     ) {
         this.module = ovale.createModule(
             "OvaleSigil",
@@ -84,46 +82,35 @@ export class OvaleSigilClass implements StateModule {
                 "UNIT_SPELLCAST_SUCCEEDED",
                 this.handleUnitSpellCastSucceeded
             );
-            this.module.RegisterEvent(
-                "COMBAT_LOG_EVENT_UNFILTERED",
-                this.handleCombatLogEventUnfiltered
+            this.module.RegisterMessage(
+                "Ovale_CombatLogEvent",
+                this.handleOvaleCombatLogEvent
             );
+            this.combatLogEvent.registerEvent("SPELL_AURA_APPLIED", this);
         }
     };
     private handleDisable = () => {
         if (this.ovale.playerClass == "DEMONHUNTER") {
             this.module.UnregisterEvent("UNIT_SPELLCAST_SUCCEEDED");
-            this.module.RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED");
+            this.module.UnregisterMessage("Ovale_CombatLogEvent");
+            this.combatLogEvent.unregisterEvent("SPELL_AURA_APPLIED", this);
         }
     };
 
-    private handleCombatLogEventUnfiltered = (
-        event: string,
-        ...parameters: any[]
-    ) => {
-        if (!this.ovalePaperDoll.isSpecialization("vengeance")) {
+    private handleOvaleCombatLogEvent = (event: string, cleuEvent: string) => {
+        if (
+            cleuEvent != "SPELL_AURA_APPLIED" ||
+            !this.ovalePaperDoll.isSpecialization("vengeance")
+        ) {
             return;
         }
-        const [
-            ,
-            cleuEvent,
-            ,
-            sourceGUID,
-            ,
-            ,
-            ,
-            ,
-            ,
-            ,
-            ,
-            spellid,
-        ] = CombatLogGetCurrentEventInfo();
-        if (
-            sourceGUID == this.ovale.playerGUID &&
-            cleuEvent == "SPELL_AURA_APPLIED"
-        ) {
-            if (sigilEnd[spellid] != undefined) {
-                const s = sigilEnd[spellid];
+        const cleu = this.combatLogEvent;
+        const sourceGUID = cleu.sourceGUID;
+        if (sourceGUID == this.ovale.playerGUID) {
+            const header = cleu.header as SpellPayloadHeader;
+            const spellId = header.spellId;
+            if (sigilEnd[spellId] != undefined) {
+                const s = sigilEnd[spellId];
                 const t = s.type;
                 remove(activatedSigils[t], 1);
             }

--- a/src/states/Enemies.ts
+++ b/src/states/Enemies.ts
@@ -91,12 +91,12 @@ export class OvaleEnemiesClass extends States<EnemiesData> {
             "PLAYER_REGEN_DISABLED",
             this.handlePlayerRegenDisabled
         );
-        this.module.RegisterMessage(
-            "Ovale_CombatLogEvent",
-            this.handleOvaleCombatLogEvent
-        );
         for (const [event] of pairs(tagEvent)) {
-            this.combatLogEvent.registerEvent(event, this);
+            this.combatLogEvent.registerEvent(
+                event,
+                this,
+                this.handleCombatLogEvent
+            );
         }
     };
 
@@ -106,16 +106,10 @@ export class OvaleEnemiesClass extends States<EnemiesData> {
             reaperTimer = undefined;
         }
         this.module.UnregisterEvent("PLAYER_REGEN_DISABLED");
-        this.module.UnregisterMessage("Ovale_CombatLogEvent");
-        for (const [event] of pairs(tagEvent)) {
-            this.combatLogEvent.unregisterEvent(event, this);
-        }
+        this.combatLogEvent.unregisterAllEvents(this);
     };
 
-    private handleOvaleCombatLogEvent = (event: string, cleuEvent: string) => {
-        if (!unitRemovedEvents[cleuEvent] && !tagEvent[cleuEvent]) {
-            return;
-        }
+    private handleCombatLogEvent = (cleuEvent: string) => {
         const cleu = this.combatLogEvent;
         const sourceGUID = cleu.sourceGUID;
         const sourceName = cleu.sourceName;

--- a/src/states/Future.ts
+++ b/src/states/Future.ts
@@ -20,7 +20,6 @@ import {
     kpairs,
     unpack,
 } from "@wowts/lua";
-import { sub } from "@wowts/string";
 import { insert, remove } from "@wowts/table";
 import {
     GetSpellInfo,
@@ -30,7 +29,6 @@ import {
     UnitChannelInfo,
     UnitExists,
     UnitGUID,
-    CombatLogGetCurrentEventInfo,
 } from "@wowts/wow-mock";
 import { OvaleStateClass, StateModule, States } from "../engine/state";
 import { OvaleCooldownClass } from "./Cooldown";
@@ -38,6 +36,11 @@ import { BaseState } from "./BaseState";
 import { isNumber } from "../tools/tools";
 import { OvaleClass } from "../Ovale";
 import { AceModule } from "@wowts/tsaddon";
+import {
+    CombatLogEvent,
+    DamagePayload,
+    SpellPayloadHeader,
+} from "../engine/combat-log-event";
 import { Tracer, DebugTools } from "../engine/debug";
 import { OvaleStanceClass } from "./Stance";
 import { OvaleSpellBookClass } from "./SpellBook";
@@ -169,6 +172,7 @@ export class OvaleFutureClass
         ovaleDebug: DebugTools,
         private ovaleStance: OvaleStanceClass,
         private ovaleSpellBook: OvaleSpellBookClass,
+        private combatLogEvent: CombatLogEvent,
         private runner: Runner
     ) {
         super(OvaleFutureData);
@@ -234,10 +238,6 @@ export class OvaleFutureClass
 
     private handleInitialize = () => {
         this.module.RegisterEvent(
-            "COMBAT_LOG_EVENT_UNFILTERED",
-            this.handleCombatLogEventUnfiltered
-        );
-        this.module.RegisterEvent(
             "PLAYER_ENTERING_WORLD",
             this.handlePlayerEnteringWorld
         );
@@ -290,12 +290,18 @@ export class OvaleFutureClass
             "Ovale_AuraChanged",
             this.handleAuraChanged
         );
+        this.module.RegisterMessage(
+            "Ovale_CombatLogEvent",
+            this.handleOvaleCombatLogEvent
+        );
+        for (const [event] of pairs(spellCastEvents)) {
+            this.combatLogEvent.registerEvent(event, this);
+        }
         this.lastSpell.registerSpellcastInfo(this);
     };
 
     private handleDisable = () => {
         this.lastSpell.unregisterSpellcastInfo(this);
-        this.module.UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED");
         this.module.UnregisterEvent("PLAYER_ENTERING_WORLD");
         this.module.UnregisterEvent("UNIT_SPELLCAST_CHANNEL_START");
         this.module.UnregisterEvent("UNIT_SPELLCAST_CHANNEL_STOP");
@@ -310,96 +316,102 @@ export class OvaleFutureClass
         this.module.UnregisterEvent("UNIT_SPELLCAST_SUCCEEDED");
         this.module.UnregisterMessage("Ovale_AuraAdded");
         this.module.UnregisterMessage("Ovale_AuraChanged");
+        this.module.UnregisterMessage("Ovale_CombatLogEvent");
+        for (const [event] of pairs(spellCastEvents)) {
+            this.combatLogEvent.unregisterEvent(event, this);
+        }
     };
 
-    private handleCombatLogEventUnfiltered = (
-        event: string,
-        ...parameters: any[]
-    ) => {
-        // this.tracer.DebugTimestamp(
-        //     "COMBAT_LOG_EVENT_UNFILTERED",
-        //     CombatLogGetCurrentEventInfo()
-        // );
-        const [
-            ,
-            cleuEvent,
-            ,
-            sourceGUID,
-            sourceName,
-            ,
-            ,
-            destGUID,
-            destName,
-            ,
-            ,
-            spellId,
-            spellName,
-            ,
-            ,
-            ,
-            ,
-            ,
-            ,
-            ,
-            ,
-            ,
-            ,
-            isOffHand,
-        ] = CombatLogGetCurrentEventInfo();
+    private handleOvaleCombatLogEvent = (event: string, cleuEvent: string) => {
+        if (!spellCastEvents[cleuEvent]) {
+            return;
+        }
+        const cleu = this.combatLogEvent;
+        const sourceGUID = cleu.sourceGUID;
+        const sourceName = cleu.sourceName;
+        const destGUID = cleu.destGUID;
+        const destName = cleu.destName;
         if (
             sourceGUID == this.ovale.playerGUID ||
             this.ovaleGuid.getOwnerGUIDByGUID(sourceGUID) ==
                 this.ovale.playerGUID
         ) {
-            if (spellCastEvents[cleuEvent]) {
+            const header = cleu.header as SpellPayloadHeader;
+            const spellId = header.spellId;
+            const spellName = header.spellName;
+            if (
+                (cleuEvent == "SPELL_CAST_FAILED" ||
+                    cleuEvent == "SPELL_CAST_START" ||
+                    cleuEvent == "SPELL_CAST_SUCCESS") &&
+                destName &&
+                destName != ""
+            ) {
+                this.tracer.debugTimestamp(event, cleu.getCurrentEventInfo());
                 const now = GetTime();
+                const [spellcast] = this.getSpellcast(
+                    spellName,
+                    spellId,
+                    undefined,
+                    now
+                );
                 if (
-                    sub(cleuEvent, 1, 11) == "SPELL_CAST_" &&
-                    destName &&
-                    destName != ""
+                    spellcast &&
+                    spellcast.targetName &&
+                    spellcast.targetName == destName &&
+                    spellcast.target != destGUID
                 ) {
-                    this.tracer.debugTimestamp(
-                        "CLEU",
-                        cleuEvent,
-                        sourceName,
-                        sourceGUID,
-                        destName,
-                        destGUID,
-                        spellId,
-                        spellName
-                    );
-                    const [spellcast] = this.getSpellcast(
+                    this.tracer.debug(
+                        "Disambiguating target of spell %s (%d) to %s (%s).",
                         spellName,
                         spellId,
-                        undefined,
-                        now
+                        destName,
+                        destGUID
                     );
+                    spellcast.target = destGUID;
+                }
+            }
+            this.tracer.debugTimestamp(event, cleu.getCurrentEventInfo());
+            let finish: "hit" | "miss" | undefined =
+                spellCastFinishEvents[cleuEvent];
+            if (cleu.payload.type == "DAMAGE") {
+                const payload = cleu.payload as DamagePayload;
+                if (payload.isOffHand) {
+                    finish = undefined;
+                }
+            }
+            if (finish) {
+                let anyFinished = false;
+                for (let i = lualength(this.lastSpell.queue); i >= 1; i += -1) {
+                    const spellcast = this.lastSpell.queue[i];
                     if (
-                        spellcast &&
-                        spellcast.targetName &&
-                        spellcast.targetName == destName &&
-                        spellcast.target != destGUID
+                        spellcast.success &&
+                        (spellcast.spellId == spellId ||
+                            spellcast.auraId == spellId)
                     ) {
-                        this.tracer.debug(
-                            "Disambiguating target of spell %s (%d) to %s (%s).",
-                            spellName,
-                            spellId,
-                            destName,
-                            destGUID
-                        );
-                        spellcast.target = destGUID;
+                        if (
+                            this.finishSpell(
+                                spellcast,
+                                cleuEvent,
+                                sourceName,
+                                sourceGUID,
+                                destName,
+                                destGUID,
+                                spellId,
+                                spellName,
+                                finish,
+                                i
+                            )
+                        ) {
+                            anyFinished = true;
+                        }
                     }
                 }
-                this.tracer.debugTimestamp("CLUE", cleuEvent);
-                let finish: "hit" | "miss" | undefined =
-                    spellCastFinishEvents[cleuEvent];
-                if (cleuEvent == "SPELL_DAMAGE" || cleuEvent == "SPELL_HEAL") {
-                    if (isOffHand) {
-                        finish = undefined;
-                    }
-                }
-                if (finish) {
-                    let anyFinished = false;
+                if (!anyFinished) {
+                    this.tracer.debug(
+                        "Found no spell to finish for %s (%d)",
+                        spellName,
+                        spellId
+                    );
                     for (
                         let i = lualength(this.lastSpell.queue);
                         i >= 1;
@@ -408,8 +420,7 @@ export class OvaleFutureClass
                         const spellcast = this.lastSpell.queue[i];
                         if (
                             spellcast.success &&
-                            (spellcast.spellId == spellId ||
-                                spellcast.auraId == spellId)
+                            spellcast.spellName == spellName
                         ) {
                             if (
                                 this.finishSpell(
@@ -431,45 +442,10 @@ export class OvaleFutureClass
                     }
                     if (!anyFinished) {
                         this.tracer.debug(
-                            "Found no spell to finish for %s (%d)",
+                            "No spell found for %s",
                             spellName,
                             spellId
                         );
-                        for (
-                            let i = lualength(this.lastSpell.queue);
-                            i >= 1;
-                            i += -1
-                        ) {
-                            const spellcast = this.lastSpell.queue[i];
-                            if (
-                                spellcast.success &&
-                                spellcast.spellName == spellName
-                            ) {
-                                if (
-                                    this.finishSpell(
-                                        spellcast,
-                                        cleuEvent,
-                                        sourceName,
-                                        sourceGUID,
-                                        destName,
-                                        destGUID,
-                                        spellId,
-                                        spellName,
-                                        finish,
-                                        i
-                                    )
-                                ) {
-                                    anyFinished = true;
-                                }
-                            }
-                        }
-                        if (!anyFinished) {
-                            this.tracer.debug(
-                                "No spell found for %s",
-                                spellName,
-                                spellId
-                            );
-                        }
                     }
                 }
             }

--- a/src/states/Health.ts
+++ b/src/states/Health.ts
@@ -98,7 +98,7 @@ export class OvaleHealthClass {
         this.module.UnregisterEvent("UNIT_HEAL_ABSORB_AMOUNT_CHANGED");
         this.module.UnregisterMessage("Ovale_UnitChanged");
     };
-    private handleOvaleCombatLogEvent = (event: string, cleuEvent: string) => {
+    private handleCombatLogEvent = (cleuEvent: string) => {
         if (!healthEvent[cleuEvent]) {
             return;
         }
@@ -130,19 +130,16 @@ export class OvaleHealthClass {
         }
     };
     private handlePlayerRegenDisabled = (event: string) => {
-        this.module.RegisterMessage(
-            "Ovale_CombatLogEvent",
-            this.handleOvaleCombatLogEvent
-        );
         for (const [event] of pairs(healthEvent)) {
-            this.combatLogEvent.registerEvent(event, this);
+            this.combatLogEvent.registerEvent(
+                event,
+                this,
+                this.handleCombatLogEvent
+            );
         }
     };
     private handlePlayerRegenEnabled = (event: string) => {
-        this.module.UnregisterMessage("Ovale_CombatLogEvent");
-        for (const [event] of pairs(healthEvent)) {
-            this.combatLogEvent.unregisterEvent(event, this);
-        }
+        this.combatLogEvent.unregisterAllEvents(this);
         wipe(this.totalDamage);
         wipe(this.totalHealing);
         wipe(this.firstSeen);


### PR DESCRIPTION
Move all `COMBAT_LOG_EVENT`-related code to a new module and teach
all modules to use it instead.  The benefits of using the
`CombatLogEvent` module are mainly for type-safety.