### PR TITLE
fix: cleanup Stagger module

### DIFF
--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -273,10 +273,10 @@ export class IoC {
         );
         this.stagger = new OvaleStaggerClass(
             this.ovale,
-            combat,
-            this.baseState,
+            this.debug,
             this.aura,
             this.health,
+            this.paperDoll,
             this.combatLogEvent
         );
         this.actionBar = new OvaleActionBarClass(
@@ -466,7 +466,6 @@ export class IoC {
         this.state.registerState(this.health);
         this.state.registerState(this.lossOfControl);
         this.state.registerState(this.power);
-        this.state.registerState(this.stagger);
         this.state.registerState(this.stance);
         this.state.registerState(this.totem);
         this.state.registerState(this.variables);

--- a/src/states/Stagger.ts
+++ b/src/states/Stagger.ts
@@ -1,9 +1,8 @@
 import { SpellId, UnitStagger } from "@wowts/wow-mock";
-import { LuaArray, lualength, pairs } from "@wowts/lua";
-import { insert, remove } from "@wowts/table";
+import aceEvent, { AceEvent } from "@wowts/ace_event-3.0";
+import { LuaArray, pairs } from "@wowts/lua";
+import { AceModule } from "@wowts/tsaddon";
 import { OvaleClass } from "../Ovale";
-import { StateModule } from "../engine/state";
-import { OvaleCombatClass } from "./combat";
 import {
     CombatLogEvent,
     DamagePayload,
@@ -11,36 +10,158 @@ import {
 } from "../engine/combat-log-event";
 import {
     ConditionFunction,
-    ConditionResult,
     OvaleConditionClass,
-    parseCondition,
     returnConstant,
     returnValueBetween,
 } from "../engine/condition";
+import { DebugTools, Tracer } from "../engine/debug";
 import { OvaleAuraClass } from "./Aura";
 import { OvaleHealthClass } from "./Health";
+import { OvalePaperDollClass } from "./PaperDoll";
+import { Deque } from "../tools/Queue";
 import { isNumber } from "../tools/tools";
-import { BaseState } from "./BaseState";
 import { AstFunctionNode, NamedParametersOf } from "../engine/ast";
 
-let serial = 1;
-const maxLength = 30;
-export class OvaleStaggerClass implements StateModule {
-    staggerTicks: LuaArray<number> = {};
+const staggerAuraId: LuaArray<boolean> = {
+    [SpellId.heavy_stagger_buff]: true,
+    [SpellId.moderate_stagger_buff]: true,
+    [SpellId.light_stagger_buff]: true,
+};
+
+export class OvaleStaggerClass {
+    private module: AceModule & AceEvent;
+    private tracer: Tracer;
+    // keep a history of the last 30 ticks of Stagger
+    private staggerTicks = new Deque<number>(30, true);
 
     constructor(
         private ovale: OvaleClass,
-        private combat: OvaleCombatClass,
-        private baseState: BaseState,
+        debug: DebugTools,
         private aura: OvaleAuraClass,
         private health: OvaleHealthClass,
+        private paperDoll: OvalePaperDollClass,
         private combatLogEvent: CombatLogEvent
     ) {
-        ovale.createModule(
+        this.module = ovale.createModule(
             "OvaleStagger",
-            this.handleInitialize,
-            this.handleDisable
+            this.onEnable,
+            this.onDisable,
+            aceEvent
         );
+        this.tracer = debug.create(this.module.GetName());
+    }
+
+    private onEnable = () => {
+        if (this.ovale.playerClass == "MONK") {
+            this.module.RegisterMessage(
+                "Ovale_SpecializationChanged",
+                this.onOvaleSpecializationChanged
+            );
+        }
+        const specialization = this.paperDoll.getSpecialization();
+        this.onOvaleSpecializationChanged(
+            "onEnable",
+            specialization,
+            specialization
+        );
+    };
+
+    private onDisable = () => {
+        if (this.ovale.playerClass == "MONK") {
+            this.module.UnregisterMessage("Ovale_SpecializationChanged");
+            this.module.UnregisterMessage("Ovale_AuraRemoved");
+            this.combatLogEvent.unregisterAllEvents(this);
+            this.emptyTickQueue();
+        }
+    };
+
+    private onOvaleSpecializationChanged = (
+        event: string,
+        newSpecialization: string,
+        oldSpecialization: string
+    ) => {
+        if (newSpecialization == "brewmaster") {
+            this.tracer.debug("Installing stagger event handlers.");
+            this.module.RegisterMessage(
+                "Ovale_AuraRemoved",
+                this.onOvaleAuraRemoved
+            );
+            this.combatLogEvent.registerEvent(
+                "SPELL_PERIODIC_DAMAGE",
+                this,
+                this.onSpellPeriodicDamage
+            );
+        } else {
+            this.tracer.debug("Removing stagger event handlers.");
+            this.module.UnregisterMessage("Ovale_AuraRemoved");
+            this.combatLogEvent.unregisterAllEvents(this);
+            this.emptyTickQueue();
+        }
+    };
+
+    private onOvaleAuraRemoved = (
+        event: string,
+        atTime: number,
+        guid: string,
+        auraId: number,
+        caster: string
+    ) => {
+        if (staggerAuraId[auraId]) {
+            const stagger = UnitStagger("player");
+            if (stagger === 0) {
+                this.tracer.debug("Empty stagger pool; clearing ticks.");
+                this.emptyTickQueue();
+            }
+        }
+    };
+
+    private onSpellPeriodicDamage = (cleuEvent: string) => {
+        const cleu = this.combatLogEvent;
+        if (cleu.sourceGUID == this.ovale.playerGUID) {
+            const header = cleu.header as SpellPeriodicPayloadHeader;
+            if (header.spellId == SpellId.stagger_buff) {
+                const payload = cleu.payload as DamagePayload;
+                const amount = payload.amount;
+                this.tracer.debug(
+                    `stagger tick ${amount} (${this.staggerTicks.length})`
+                );
+                this.staggerTicks.push(amount);
+            }
+        }
+    };
+
+    private emptyTickQueue = () => {
+        const queue = this.staggerTicks;
+        // TODO replace with queue.clear() when available
+        queue.first = 0;
+        queue.last = 0;
+        queue.length = 0;
+    };
+
+    private getAnyStaggerAura(atTime: number) {
+        for (const [auraId] of pairs(staggerAuraId)) {
+            const aura = this.aura.getAura("player", auraId, atTime, "HARMFUL");
+            if (aura && this.aura.isActiveAura(aura, atTime)) {
+                return aura;
+            }
+        }
+        return undefined;
+    }
+
+    lastTickDamage(countTicks?: number): number {
+        if (!countTicks || countTicks === 0 || countTicks < 0) {
+            countTicks = 1;
+        }
+        let damage = 0;
+        const queue = this.staggerTicks;
+        for (let i = queue.length; i >= 1; i--) {
+            if (countTicks > 0) {
+                const amount = queue.at(i) || 0;
+                damage += amount;
+                countTicks -= 1;
+            }
+        }
+        return damage;
     }
 
     public registerConditions(ovaleCondition: OvaleConditionClass) {
@@ -71,65 +192,9 @@ export class OvaleStaggerClass implements StateModule {
         );
     }
 
-    private handleInitialize = () => {
-        if (this.ovale.playerClass == "MONK") {
-            this.combatLogEvent.registerEvent(
-                "SPELL_PERIODIC_DAMAGE",
-                this,
-                this.handleSpellPeriodicDamage
-            );
-        }
-    };
-    private handleDisable = () => {
-        if (this.ovale.playerClass == "MONK") {
-            this.combatLogEvent.unregisterAllEvents(this);
-        }
-    };
-    private handleSpellPeriodicDamage = (cleuEvent: string) => {
-        const cleu = this.combatLogEvent;
-        if (cleu.sourceGUID == this.ovale.playerGUID) {
-            serial = serial + 1;
-            const header = cleu.header as SpellPeriodicPayloadHeader;
-            if (header.spellId == SpellId.stagger_buff) {
-                const payload = cleu.payload as DamagePayload;
-                insert(this.staggerTicks, payload.amount);
-                if (lualength(this.staggerTicks) > maxLength) {
-                    remove(this.staggerTicks, 1);
-                }
-            }
-        }
-    };
-
-    cleanState(): void {}
-    initializeState(): void {}
-    resetState(): void {
-        if (!this.combat.isInCombat(undefined)) {
-            for (const [k] of pairs(this.staggerTicks)) {
-                delete this.staggerTicks[k];
-            }
-        }
-    }
-
-    lastTickDamage(countTicks: number): number {
-        if (!countTicks || countTicks == 0 || countTicks < 0) countTicks = 1;
-
-        let damage = 0;
-        const arrLen = lualength(this.staggerTicks);
-
-        if (arrLen < 1) return 0;
-
-        for (let i = arrLen; i > arrLen - (countTicks - 1); i += -1) {
-            damage += this.staggerTicks[i] || 0;
-        }
-        return damage;
-    }
-
     /** Get the remaining amount of damage Stagger will cause to the target.
 	 @name StaggerRemaining
 	 @paramsig number
-	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
-	     Defaults to target=player.
-	     Valid values: player, target, focus, pet.
 	 @return The amount of damage.
 	 @usage
 	 if StaggerRemaining() / MaxHealth() >0.4 Spell(purifying_brew)
@@ -139,57 +204,31 @@ export class OvaleStaggerClass implements StateModule {
         namedParams: NamedParametersOf<AstFunctionNode>,
         atTime: number
     ) => {
-        const [target] = parseCondition(namedParams, this.baseState);
-        return this.getAnyStaggerAura(target, atTime);
-    };
-
-    private getAnyStaggerAura(target: string, atTime: number): ConditionResult {
-        let aura = this.aura.getAura(
-            target,
-            SpellId.heavy_stagger_buff,
-            atTime,
-            "HARMFUL"
-        );
-        if (!aura || !this.aura.isActiveAura(aura, atTime)) {
-            aura = this.aura.getAura(
-                target,
-                SpellId.moderate_stagger_buff,
-                atTime,
-                "HARMFUL"
-            );
-        }
-        if (!aura || !this.aura.isActiveAura(aura, atTime)) {
-            aura = this.aura.getAura(
-                target,
-                SpellId.light_stagger_buff,
-                atTime,
-                "HARMFUL"
-            );
-        }
-        if (aura && this.aura.isActiveAura(aura, atTime)) {
+        const aura = this.getAnyStaggerAura(atTime);
+        if (aura) {
             const [gain, start, ending] = [aura.gain, aura.start, aura.ending];
-            const stagger = UnitStagger(target);
+            const stagger = UnitStagger("player");
             const rate = (-1 * stagger) / (ending - start);
             return returnValueBetween(gain, ending, 0, ending, rate);
         }
         return [];
-    }
+    };
 
     private staggerPercent: ConditionFunction = (
         positionalparameters,
         namedParams,
         atTime
     ) => {
-        const [target] = parseCondition(namedParams, this.baseState);
-        let [start, ending, value, origin, rate] = this.getAnyStaggerAura(
-            target,
+        let [start, ending, value, origin, rate] = this.staggerRemaining(
+            positionalparameters,
+            namedParams,
             atTime
         );
-        const healthMax = this.health.getUnitHealthMax(target);
-        if (value !== undefined && isNumber(value)) {
+        const healthMax = this.health.getUnitHealthMax("player");
+        if (value && isNumber(value)) {
             value = (value * 100) / healthMax;
         }
-        if (rate !== undefined) {
+        if (rate) {
             rate = (rate * 100) / healthMax;
         }
         return [start, ending, value, origin, rate];
@@ -200,16 +239,16 @@ export class OvaleStaggerClass implements StateModule {
         namedParams,
         atTime
     ) => {
-        const [target] = parseCondition(namedParams, this.baseState);
-        let [start, ending, value, origin, rate] = this.getAnyStaggerAura(
-            target,
+        let [start, ending, value, origin, rate] = this.staggerRemaining(
+            positionalparameters,
+            namedParams,
             atTime
         );
-        const healthMax = this.health.getUnitHealthMax(target);
-        if (value !== undefined && isNumber(value)) {
+        const healthMax = this.health.getUnitHealthMax("player");
+        if (value && isNumber(value)) {
             value = ((healthMax - value) * 100) / healthMax;
         }
-        if (rate !== undefined) {
+        if (rate) {
             rate = -(rate * 100) / healthMax;
         }
         return [start, ending, value, origin, rate];
@@ -219,9 +258,6 @@ export class OvaleStaggerClass implements StateModule {
 	 @name StaggerTick
      @paramsig number or boolean
      @param count Optional. Counts n amount of previous stagger ticks.
-	 @param target Optional. Sets the target to check. The target may also be given as a prefix to the condition.
-	     Defaults to target=player.
-	     Valid values: player, target, focus, pet.
 	 @return Stagger tick damage.
 	 @usage
      if StaggerTick() > 1000 Spell(purifying_brew) #return current tick of stagger


### PR DESCRIPTION
* OvaleStaggerClass is not a StateModule.
* Remove unused variables and imports.
* Maintain a queue of recent Stagger ticks.
* Only track Stagger ticks for Brewmaster monks.
* Empty queue when Stagger pool is empty, not when combat ends.