### PR TITLE
fix: rewrite demon hunter modules to correctly handle state

### DIFF
--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -131,6 +131,7 @@ export class IoC {
         const runner = new Runner(this.debug, this.baseState, this.condition);
         this.data = new OvaleDataClass(runner, this.debug);
         this.combatLogEvent = new CombatLogEvent(this.ovale, this.debug);
+        this.guid = new Guids(this.ovale, this.debug);
         this.equipment = new OvaleEquipmentClass(
             this.ovale,
             this.debug,
@@ -141,7 +142,9 @@ export class IoC {
             this.ovale,
             this.debug
         );
-        this.guid = new Guids(this.ovale, this.debug);
+        const covenant = new Covenant(this.ovale, this.debug);
+        const runeforge = new Runeforge(this.ovale, this.debug, this.equipment);
+        const soulbind = new Soulbind(this.ovale, this.debug);
         this.spellBook = new OvaleSpellBookClass(
             this.ovale,
             this.debug,
@@ -155,10 +158,10 @@ export class IoC {
             this.debug
         );
         this.demonHunterSigils = new OvaleSigilClass(
-            this.paperDoll,
             this.ovale,
-            this.spellBook,
-            this.combatLogEvent
+            this.debug,
+            this.paperDoll,
+            this.spellBook
         );
         const combat = new OvaleCombatClass(
             this.ovale,
@@ -423,9 +426,6 @@ export class IoC {
             controls
         );
         this.recount = new OvaleRecountClass(this.ovale, this.score);
-        const covenant = new Covenant(this.ovale, this.debug);
-        const runeforge = new Runeforge(this.ovale, this.debug, this.equipment);
-        const soulbind = new Soulbind(this.ovale, this.debug);
         this.conditions = new OvaleConditions(
             this.condition,
             this.data,

--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -327,10 +327,11 @@ export class IoC {
             this.combatLogEvent
         );
         this.demonHunterSoulFragments = new OvaleDemonHunterSoulFragmentsClass(
-            this.aura,
             this.ovale,
-            this.paperDoll,
-            this.combatLogEvent
+            this.debug,
+            this.aura,
+            this.combatLogEvent,
+            this.paperDoll
         );
         this.runes = new OvaleRunesClass(
             this.ovale,

--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -402,7 +402,8 @@ export class IoC {
         this.bossMod = new OvaleBossModClass(this.ovale, this.debug, combat);
         this.demonHunterDemonic = new OvaleDemonHunterDemonicClass(
             this.aura,
-            this.combatLogEvent,
+            this.paperDoll,
+            this.spellBook,
             this.ovale,
             this.debug
         );

--- a/src/states/DemonHunterDemonic.ts
+++ b/src/states/DemonHunterDemonic.ts
@@ -94,7 +94,7 @@ export class OvaleDemonHunterDemonicClass implements StateModule {
         if (this.specialization == "havoc") {
             this.hasDemonicTalent =
                 this.spellBook.getTalentPoints(TalentId.demonic_talent) > 0;
-        } else if (this.specialization == "vengenace") {
+        } else if (this.specialization == "vengeance") {
             this.hasDemonicTalent =
                 this.spellBook.getTalentPoints(
                     TalentId.demonic_talent_vengeance

--- a/src/states/DemonHunterDemonic.ts
+++ b/src/states/DemonHunterDemonic.ts
@@ -52,15 +52,12 @@ export class OvaleDemonHunterDemonicClass implements StateModule {
                 "Ovale_SpecializationChanged",
                 this.onOvaleSpecializationChanged
             );
-            if (this.paperDoll.isSpecialization("havoc")) {
-                this.onOvaleSpecializationChanged("onEnable", "havoc", "havoc");
-            } else if (this.paperDoll.isSpecialization("vengeance")) {
-                this.onOvaleSpecializationChanged(
-                    "onEnable",
-                    "vengeance",
-                    "vengeance"
-                );
-            }
+            const specialization = this.paperDoll.getSpecialization();
+            this.onOvaleSpecializationChanged(
+                "onEnable",
+                specialization,
+                specialization
+            );
         }
     };
 

--- a/src/states/DemonHunterDemonic.ts
+++ b/src/states/DemonHunterDemonic.ts
@@ -1,190 +1,157 @@
-import { OvaleAuraClass } from "./Aura";
 import aceEvent, { AceEvent } from "@wowts/ace_event-3.0";
-import {
-    GetSpecialization,
-    GetSpecializationInfo,
-    GetTime,
-    GetTalentInfoByID,
-} from "@wowts/wow-mock";
-import { huge } from "@wowts/math";
-import { select } from "@wowts/lua";
-import { OvaleClass } from "../Ovale";
+import { LuaArray, LuaObj } from "@wowts/lua";
+import { SpellId, TalentId } from "@wowts/wow-mock";
 import { AceModule } from "@wowts/tsaddon";
-import { CombatLogEvent, SpellPayloadHeader } from "../engine/combat-log-event";
 import { DebugTools, Tracer } from "../engine/debug";
+import { SpellCastEventHandler, StateModule } from "../engine/state";
+import { OvaleClass } from "../Ovale";
+import { OvaleAuraClass } from "./Aura";
+import { OvalePaperDollClass } from "./PaperDoll";
+import { OvaleSpellBookClass } from "./SpellBook";
 
-const infinity = huge;
-const havocDemonicTalentId = 22547;
-const havocSpecId = 577;
-const havocEyeBeamSpellId = 198013;
-const havocMetaBuffId = 162264;
-const hiddenBuffId = -havocDemonicTalentId;
-const hiddenBuffDuration = infinity;
-const hiddenBuffExtendedByDemonic = "Extended by Demonic";
+const demonicTriggerId: LuaObj<LuaArray<boolean>> = {
+    havoc: {
+        [SpellId.eye_beam]: true,
+    },
+    vengeance: {
+        [SpellId.fel_devastation]: true,
+    },
+};
 
-export class OvaleDemonHunterDemonicClass {
-    playerGUID: string;
-    isDemonHunter = false;
-    isHavoc: boolean;
-    hasDemonic: boolean;
+const metamorphosisId: LuaObj<number> = {
+    havoc: SpellId.metamorphosis,
+    vengeance: SpellId.metamorphosis_vengeance,
+};
 
+export class OvaleDemonHunterDemonicClass implements StateModule {
     private module: AceModule & AceEvent;
-    private debug: Tracer;
+    private tracer: Tracer;
+
+    private specialization = "havoc";
+    private hasDemonicTalent = false;
 
     constructor(
-        private ovaleAura: OvaleAuraClass,
-        private combatLogEvent: CombatLogEvent,
+        private aura: OvaleAuraClass,
+        private paperDoll: OvalePaperDollClass,
+        private spellBook: OvaleSpellBookClass,
         private ovale: OvaleClass,
-        ovaleDebug: DebugTools
+        debug: DebugTools
     ) {
         this.module = ovale.createModule(
             "OvaleDemonHunterDemonic",
-            this.handleInitialize,
-            this.handleDisable,
+            this.onEnable,
+            this.onDisable,
             aceEvent
         );
-        this.debug = ovaleDebug.create(this.module.GetName());
-        this.playerGUID = this.ovale.playerGUID;
-        this.isHavoc = false;
-        this.hasDemonic = false;
+        this.tracer = debug.create(this.module.GetName());
     }
 
-    private handleInitialize = () => {
-        this.isDemonHunter =
-            (this.ovale.playerClass == "DEMONHUNTER" && true) || false;
-        if (this.isDemonHunter) {
-            this.debug.debug("playerGUID: (%s)", this.ovale.playerGUID);
+    private onEnable = () => {
+        if (this.ovale.playerClass == "DEMONHUNTER") {
+            this.module.RegisterMessage(
+                "Ovale_SpecializationChanged",
+                this.onOvaleSpecializationChanged
+            );
+            if (this.paperDoll.isSpecialization("havoc")) {
+                this.onOvaleSpecializationChanged("onEnable", "havoc", "havoc");
+            } else if (this.paperDoll.isSpecialization("vengeance")) {
+                this.onOvaleSpecializationChanged(
+                    "onEnable",
+                    "vengeance",
+                    "vengeance"
+                );
+            }
+        }
+    };
+
+    private onDisable = () => {
+        if (this.ovale.playerClass == "DEMONHUNTER") {
+            this.module.UnregisterMessage("Ovale_SpecializationChanged");
+            this.module.UnregisterMessage("Ovale_TalentsChanged");
+            this.hasDemonicTalent = false;
+        }
+    };
+
+    private onOvaleSpecializationChanged = (
+        event: string,
+        newSpecialization: string,
+        oldSpecialization: string
+    ) => {
+        this.specialization = newSpecialization;
+        if (newSpecialization == "havoc" || newSpecialization == "vengeance") {
+            this.tracer.debug("Installing Demonic event handlers.");
             this.module.RegisterMessage(
                 "Ovale_TalentsChanged",
-                this.handleTalentsChanged
+                this.onOvaleTalentsChanged
             );
-        }
-    };
-    private handleDisable = () => {
-        this.module.UnregisterMessage("Ovale_TalentsChanged");
-    };
-    private handleTalentsChanged = (event: string) => {
-        this.isHavoc =
-            (this.isDemonHunter &&
-                GetSpecializationInfo(GetSpecialization()) == havocSpecId &&
-                true) ||
-            false;
-        this.hasDemonic =
-            (this.isHavoc &&
-                select(
-                    10,
-                    GetTalentInfoByID(havocDemonicTalentId, havocSpecId)
-                ) &&
-                true) ||
-            false;
-        if (this.isHavoc && this.hasDemonic) {
-            this.debug.debug("We are a havoc DH with Demonic.");
-            this.combatLogEvent.registerEvent(
-                "SPELL_CAST_SUCCESS",
-                this,
-                this.handleCombatLogEvent
-            );
-            this.combatLogEvent.registerEvent(
-                "SPELL_AURA_REMOVED",
-                this,
-                this.handleCombatLogEvent
-            );
+            this.onOvaleTalentsChanged(event);
         } else {
-            if (!this.isHavoc) {
-                this.debug.debug("We are not a havoc DH.");
-            } else if (!this.hasDemonic) {
-                this.debug.debug("We don't have the Demonic talent.");
-            }
-            this.dropAura();
-            this.combatLogEvent.unregisterAllEvents(this);
+            this.tracer.debug("Removing Demonic event handlers.");
+            this.module.UnregisterMessage("Ovale_TalentsChanged");
+            this.hasDemonicTalent = false;
         }
     };
-    private handleCombatLogEvent(cleuEvent: string) {
-        const cleu = this.combatLogEvent;
-        if (cleu.sourceGUID == this.playerGUID) {
-            if (cleuEvent == "SPELL_CAST_SUCCESS") {
-                const header = cleu.header as SpellPayloadHeader;
-                const spellId = header.spellId;
-                const spellName = header.spellName;
-                if (havocEyeBeamSpellId == spellId) {
-                    this.debug.debug(
-                        "Spell %d (%s) has successfully been cast. Gaining Aura (only during meta).",
-                        spellId,
-                        spellName
-                    );
-                    this.gainAura();
-                }
-            } else if (cleuEvent == "SPELL_AURA_REMOVED") {
-                const header = cleu.header as SpellPayloadHeader;
-                const spellId = header.spellId;
-                const spellName = header.spellName;
-                if (havocMetaBuffId == spellId) {
-                    this.debug.debug(
-                        "Aura %d (%s) is removed. Dropping Aura.",
-                        spellId,
-                        spellName
-                    );
-                    this.dropAura();
-                }
+
+    private onOvaleTalentsChanged = (event: string) => {
+        const hasDemonicTalent = this.hasDemonicTalent;
+        if (this.specialization == "havoc") {
+            this.hasDemonicTalent =
+                this.spellBook.getTalentPoints(TalentId.demonic_talent) > 0;
+        } else if (this.specialization == "vengenace") {
+            this.hasDemonicTalent =
+                this.spellBook.getTalentPoints(
+                    TalentId.demonic_talent_vengeance
+                ) > 0;
+        } else {
+            this.hasDemonicTalent = false;
+        }
+        if (hasDemonicTalent != this.hasDemonicTalent) {
+            if (this.hasDemonicTalent) {
+                this.tracer.debug("Gained Demonic talent.");
+            } else {
+                this.tracer.debug("Lost Demonic talent.");
             }
         }
-    }
-    gainAura() {
-        const now = GetTime();
-        const auraMeta = this.ovaleAura.getAura(
-            "player",
-            havocMetaBuffId,
-            now,
+    };
+
+    initializeState() {}
+    resetState() {}
+    cleanState() {}
+
+    applySpellAfterCast: SpellCastEventHandler = (
+        spellId,
+        targetGUID,
+        startCast,
+        endCast,
+        channel,
+        spellcast
+    ) => {
+        if (
+            this.hasDemonicTalent &&
+            demonicTriggerId[this.specialization][spellId]
+        ) {
+            /*
+             * Demonic grants 6 seconds of Metamorphosis, plus the
+             * duration of the channeled spell.
+             */
+            const duration = 6 + ((channel && endCast - startCast) || 0);
+            const atTime = (channel && startCast) || endCast;
+            this.triggerMetamorphosis(atTime, duration);
+        }
+    };
+
+    private triggerMetamorphosis = (atTime: number, duration: number) => {
+        const auraId = metamorphosisId[this.specialization];
+        this.tracer.log(`Triggering Demonic Metamorphosis (${auraId}).`);
+        this.aura.addAuraToGUID(
+            this.ovale.playerGUID,
+            auraId,
+            this.ovale.playerGUID,
             "HELPFUL",
-            true
+            undefined,
+            atTime,
+            atTime + duration,
+            atTime
         );
-        if (auraMeta && this.ovaleAura.isActiveAura(auraMeta, now)) {
-            this.debug.debug(
-                "Adding '%s' (%d) buff to player %s.",
-                hiddenBuffExtendedByDemonic,
-                hiddenBuffId,
-                this.playerGUID
-            );
-            const duration = hiddenBuffDuration;
-            const ending = now + hiddenBuffDuration;
-            this.ovaleAura.gainedAuraOnGUID(
-                this.playerGUID,
-                now,
-                hiddenBuffId,
-                this.playerGUID,
-                "HELPFUL",
-                false,
-                undefined,
-                1,
-                undefined,
-                duration,
-                ending,
-                false,
-                hiddenBuffExtendedByDemonic,
-                undefined,
-                undefined,
-                undefined
-            );
-        } else {
-            this.debug.debug(
-                "Aura 'Metamorphosis' (%d) is not present.",
-                havocMetaBuffId
-            );
-        }
-    }
-    dropAura() {
-        const now = GetTime();
-        this.debug.debug(
-            "Removing '%s' (%d) buff on player %s.",
-            hiddenBuffExtendedByDemonic,
-            hiddenBuffId,
-            this.playerGUID
-        );
-        this.ovaleAura.lostAuraOnGUID(
-            this.playerGUID,
-            now,
-            hiddenBuffId,
-            this.playerGUID
-        );
-    }
+    };
 }

--- a/src/states/DemonHunterSoulFragments.ts
+++ b/src/states/DemonHunterSoulFragments.ts
@@ -1,120 +1,267 @@
-import { OvaleAuraClass } from "./Aura";
-import { GetTime } from "@wowts/wow-mock";
-import { LuaArray } from "@wowts/lua";
+import aceEvent, { AceEvent } from "@wowts/ace_event-3.0";
+import { LuaArray, pairs } from "@wowts/lua";
+import { AceModule } from "@wowts/tsaddon";
+import { GetTime, SpellId } from "@wowts/wow-mock";
 import { OvaleClass } from "../Ovale";
-import { OvalePaperDollClass } from "./PaperDoll";
 import { CombatLogEvent, SpellPayloadHeader } from "../engine/combat-log-event";
+import { DebugTools, Tracer } from "../engine/debug";
+import { SpellCastEventHandler, States, StateModule } from "../engine/state";
+import { OvaleAuraClass } from "./Aura";
+import { OvalePaperDollClass } from "./PaperDoll";
 
-const soulFragmentsBuffId = 203981;
-const metamorphosisBuffId = 187827;
-const soulFragmentSpells: LuaArray<number> = {
+const generator: LuaArray<number> = {
     [225919]: 2, // Fracture
-    [203782]: 1, // Shear
-    [228477]: -2, // Soul Cleave
-};
-const soulFragmentFinishers: LuaArray<boolean> = {
-    [247454]: true, // Spirit Bomb
-    [263648]: true, // Soul Barrier
+    [SpellId.shear]: 1,
 };
 
-export class OvaleDemonHunterSoulFragmentsClass {
-    estimatedCount = 0;
-    atTime?: number;
-    estimated?: boolean;
+const spender: LuaArray<number> = {
+    [SpellId.soul_barrier]: -5,
+    [SpellId.soul_cleave]: -2,
+    [SpellId.spirit_bomb]: -5,
+};
+
+// Soul Fragments buff ID
+const soulFragmentsId = 203981;
+
+const trackedBuff: LuaArray<boolean> = {
+    [soulFragmentsId]: true, // Soul Fragments
+    [SpellId.metamorphosis_vengeance]: true,
+};
+
+class SoulFragmentsData {
+    count = 0; // total soul fragments, including pending spawns
+}
+
+export class OvaleDemonHunterSoulFragmentsClass
+    extends States<SoulFragmentsData>
+    implements StateModule
+{
+    private module: AceModule & AceEvent;
+    private tracer: Tracer;
+
+    private hasSoulFragmentsHandlers = false;
+    private hasMetamorphosis = false;
+    private count = 0; // stack count of Soul Fragment buff
+    private pending = 0; // pending soul fragment spawns
+    // invariant: count + pending <= 5
 
     constructor(
-        private ovaleAura: OvaleAuraClass,
         private ovale: OvaleClass,
-        private ovalePaperDoll: OvalePaperDollClass,
-        private combatLogEvent: CombatLogEvent
+        debug: DebugTools,
+        private aura: OvaleAuraClass,
+        private combatLogEvent: CombatLogEvent,
+        private paperDoll: OvalePaperDollClass
     ) {
-        ovale.createModule(
+        super(SoulFragmentsData);
+        this.module = ovale.createModule(
             "OvaleDemonHunterSoulFragments",
-            this.handleInitialize,
-            this.handleDisable
+            this.onEnable,
+            this.onDisable,
+            aceEvent
         );
+        this.tracer = debug.create(this.module.GetName());
     }
 
-    private handleInitialize = () => {
+    private onEnable = () => {
         if (this.ovale.playerClass == "DEMONHUNTER") {
-            this.combatLogEvent.registerEvent(
-                "SPELL_CAST_SUCCESS",
-                this,
-                this.handleSpellCastSuccess
+            this.module.RegisterMessage(
+                "Ovale_SpecializationChanged",
+                this.onOvaleSpecializationChanged
+            );
+            const specialization = this.paperDoll.getSpecialization();
+            this.onOvaleSpecializationChanged(
+                "onEnable",
+                specialization,
+                specialization
             );
         }
     };
 
-    private handleDisable = () => {
+    private onDisable = () => {
         if (this.ovale.playerClass == "DEMONHUNTER") {
-            this.combatLogEvent.unregisterAllEvents(this);
+            this.module.UnregisterMessage("Ovale_SpecializationChanged");
+            this.unregisterSoulFragmentsHandlers();
         }
     };
-    private handleSpellCastSuccess = (cleuEvent: string) => {
-        if (!this.ovalePaperDoll.isSpecialization("vengeance")) {
-            return;
+
+    private onOvaleSpecializationChanged = (
+        event: string,
+        newSpecialization: string,
+        oldSpecialization: string
+    ) => {
+        if (newSpecialization == "vengeance") {
+            this.registerSoulFragmentsHandlers();
+            const now = GetTime();
+            for (const [auraId] of pairs(trackedBuff)) {
+                const aura = this.aura.getAura(
+                    "player",
+                    auraId,
+                    now,
+                    "HELPFUL",
+                    true
+                );
+                if (aura && this.aura.isActiveAura(aura, now)) {
+                    this.onOvaleAuraEvent(
+                        "Ovale_AuraChanged",
+                        now,
+                        aura.guid,
+                        aura.spellId,
+                        aura.source
+                    );
+                }
+            }
+        } else {
+            this.unregisterSoulFragmentsHandlers();
         }
+    };
+
+    private registerSoulFragmentsHandlers = () => {
+        if (!this.hasSoulFragmentsHandlers) {
+            this.module.RegisterMessage(
+                "Ovale_AuraAdded",
+                this.onOvaleAuraEvent
+            );
+            this.module.RegisterMessage(
+                "Ovale_AuraChanged",
+                this.onOvaleAuraEvent
+            );
+            this.module.RegisterMessage(
+                "Ovale_AuraRemoved",
+                this.onOvaleAuraEvent
+            );
+            this.combatLogEvent.registerEvent(
+                "SPELL_CAST_SUCCESS",
+                this,
+                this.onSpellCastSuccess
+            );
+            this.hasSoulFragmentsHandlers = true;
+        }
+    };
+
+    private unregisterSoulFragmentsHandlers = () => {
+        if (this.hasSoulFragmentsHandlers) {
+            this.module.UnregisterMessage("Ovale_AuraAdded");
+            this.module.UnregisterMessage("Ovale_AuraChanged");
+            this.module.UnregisterMessage("Ovale_AuraRemoved");
+            this.combatLogEvent.unregisterAllEvents(this);
+            this.hasSoulFragmentsHandlers = false;
+
+            this.hasMetamorphosis = false;
+            this.count = 0;
+            this.pending = 0;
+            this.current.count = 0;
+        }
+    };
+
+    private onOvaleAuraEvent = (
+        event: string,
+        atTime: number,
+        guid: string,
+        auraId: number,
+        caster: string
+    ) => {
+        if (guid == this.ovale.playerGUID) {
+            if (auraId == SpellId.metamorphosis_vengeance) {
+                if (
+                    event == "Ovale_AuraAdded" ||
+                    event == "Ovale_AuraChanged"
+                ) {
+                    this.hasMetamorphosis = true;
+                } else if (event == "Ovale_AuraRemoved") {
+                    this.hasMetamorphosis = false;
+                }
+            } else if (auraId == soulFragmentsId) {
+                if (
+                    event == "Ovale_AuraAdded" ||
+                    event == "Ovale_AuraChanged"
+                ) {
+                    const aura = this.aura.getAura(
+                        "player",
+                        auraId,
+                        atTime,
+                        "HELPFUL",
+                        true
+                    );
+                    if (aura && this.aura.isActiveAura(aura, atTime)) {
+                        const gained = aura.stacks - this.count;
+                        if (gained > 0) {
+                            const pending = this.pending - gained;
+                            this.pending = (pending > 0 && pending) || 0;
+                        }
+                        this.count = aura.stacks;
+                        const count = this.count + this.pending;
+                        this.current.count = (count < 5 && count) || 5;
+                        this.pending = this.current.count - this.count;
+                        this.tracer.debug(
+                            `${this.current.count} = ${this.count} + ${this.pending}`
+                        );
+                    }
+                } else if (event == "Ovale_AuraRemoved") {
+                    this.count = 0;
+                    this.current.count = this.pending;
+                    this.tracer.debug(
+                        `${this.current.count} = ${this.count} + ${this.pending}`
+                    );
+                }
+            }
+        }
+    };
+
+    private onSpellCastSuccess = (cleuEvent: string) => {
         const cleu = this.combatLogEvent;
         if (cleu.sourceGUID == this.ovale.playerGUID) {
             const header = cleu.header as SpellPayloadHeader;
             const spellId = header.spellId;
-            if (soulFragmentSpells[spellId]) {
-                const now = GetTime();
-                let fragments = soulFragmentSpells[spellId];
-                if (fragments > 0 && this.hasMetamorphosis(now)) {
+            if (generator[spellId]) {
+                let fragments = generator[spellId];
+                if (fragments > 0 && this.hasMetamorphosis) {
+                    // Metamorphosis triggers an extra Lesser Soul Fragment
                     fragments = fragments + 1;
                 }
-                this.addPredictedSoulFragments(now, fragments);
-            } else if (soulFragmentFinishers[spellId]) {
-                const now = GetTime();
-                this.setPredictedSoulFragment(now, 0);
+                this.pending += fragments;
+                const count = this.count + this.pending;
+                this.current.count = (count < 5 && count) || 5;
+                this.pending = this.current.count - this.count;
+                this.tracer.debug(
+                    `${this.current.count} = ${this.count} + ${this.pending}`
+                );
             }
         }
     };
-    addPredictedSoulFragments(atTime: number, added: number) {
-        const currentCount = this.getSoulFragmentsBuffStacks(atTime) || 0;
-        this.setPredictedSoulFragment(atTime, currentCount + added);
+
+    initializeState(): void {}
+
+    resetState() {
+        if (this.hasSoulFragmentsHandlers) {
+            this.next.count = this.current.count;
+        }
     }
-    setPredictedSoulFragment(atTime: number, count: number) {
-        this.estimatedCount = (count < 0 && 0) || (count > 5 && 5) || count;
-        this.atTime = atTime;
-        this.estimated = true;
-    }
-    soulFragments(atTime: number) {
-        // TODO Need to add parameters greater and demon
-        let stacks = this.getSoulFragmentsBuffStacks(atTime);
-        if (this.estimated) {
-            if (atTime - (this.atTime || 0) < 1.2) {
-                stacks = this.estimatedCount;
-            } else {
-                this.estimated = false;
+
+    cleanState(): void {}
+
+    applySpellAfterCast: SpellCastEventHandler = (
+        spellId,
+        targetGUID,
+        startCast,
+        endCast,
+        channel,
+        spellcast
+    ) => {
+        if (this.hasSoulFragmentsHandlers) {
+            if (generator[spellId]) {
+                const fragments = generator[spellId];
+                const count = this.next.count + fragments;
+                this.next.count = (count < 5 && count) || 5;
+            } else if (spender[spellId]) {
+                const fragments = spender[spellId];
+                const count = this.next.count + fragments;
+                this.next.count = (count > 0 && count) || 0;
             }
         }
-        return stacks;
-    }
-    getSoulFragmentsBuffStacks(atTime: number) {
-        const aura = this.ovaleAura.getAura(
-            "player",
-            soulFragmentsBuffId,
-            atTime,
-            "HELPFUL",
-            true
-        );
-        const stacks =
-            (aura &&
-                this.ovaleAura.isActiveAura(aura, atTime) &&
-                aura.stacks) ||
-            0;
-        return stacks;
-    }
-    hasMetamorphosis(atTime: number) {
-        const aura = this.ovaleAura.getAura(
-            "player",
-            metamorphosisBuffId,
-            atTime,
-            "HELPFUL",
-            true
-        );
-        return (aura && this.ovaleAura.isActiveAura(aura, atTime)) || false;
+    };
+
+    soulFragments(atTime: number) {
+        // TODO Need to add parameters greater and demon
+        return this.next.count;
     }
 }


### PR DESCRIPTION
The demon hunter modules were not handling state correctly. In a
state module, the module registers for events to track what is
currently happening "live" in-game, and updates the current state
of the game based on those events. A state module also implements
the `StateModule` interface and does two things:

1. Update the simulator state from the current state each time
   `resetState()` is called.
2. Modify the simulator state after various `applySpell*()`
   functions are called.

Lastly, script conditions that query information from state modules
should query that information from the simulator state, not the
current state.

Make these changes to the three demon hunter modules that track the
Demonic talent, sigils, and Soul Fragments, respectively.