### PR TITLE
fix: register state for demonic and soul fragment DH modules

### DIFF
--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -472,7 +472,9 @@ export class IoC {
         this.state.registerState(this.paperDoll);
         this.state.registerState(this.baseState);
         this.state.registerState(this.bloodtalons);
+        this.state.registerState(this.demonHunterDemonic);
         this.state.registerState(this.demonHunterSigils);
+        this.state.registerState(this.demonHunterSoulFragments);
         this.state.registerState(this.eclipse);
         this.state.registerState(this.enemies);
         this.state.registerState(this.future);


### PR DESCRIPTION
This was missing from cc3923d60de8eb556893638ddfcb77bfdf4e1bdf.